### PR TITLE
Add comparison pages: Infinite Table vs AG Grid, TanStack Table, MUI X Data Grid

### DIFF
--- a/.github/ISSUE_TEMPLATE/compare_page_correction.md
+++ b/.github/ISSUE_TEMPLATE/compare_page_correction.md
@@ -1,0 +1,33 @@
+---
+name: Compare page correction
+about: Suggest a correction to a comparison page (AG Grid, TanStack Table, or MUI X Data Grid)
+title: 'Compare page correction: '
+labels: 'docs'
+assignees: ''
+
+---
+
+Thanks for helping us keep these pages accurate. We want the comparisons to be fair.
+
+**Which page?**
+
+- [ ] [/docs/learn/compare](https://infinite-table.com/docs/learn/compare)
+- [ ] [vs AG Grid](https://infinite-table.com/docs/learn/compare/ag-grid)
+- [ ] [vs TanStack Table](https://infinite-table.com/docs/learn/compare/tanstack-table)
+- [ ] [vs MUI X Data Grid](https://infinite-table.com/docs/learn/compare/mui-x-data-grid)
+
+**What should change?**
+
+A clear description of the inaccuracy, outdated claim, missing context, or unfair wording.
+
+**Source**
+
+Link to the vendor docs, changelog, or pricing page that supports the correction.
+
+**Suggested wording** (optional)
+
+If you already know how the cell, sentence, or table row should read, paste it here.
+
+**Are you affiliated with the product being compared?**
+
+Yes / no — this is optional, but it helps us follow up.

--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -1,25 +1,56 @@
 ---
 title: Infinite Table vs AG Grid
-description: A detailed comparison of Infinite Table and AG Grid for React. Architecture, features, pricing, and when AG Grid is the better choice.
+description: A detailed comparison of Infinite Table and AG Grid for React. React-native API vs framework-agnostic wrapper, features, and when AG Grid is the better choice.
 ---
 
-[AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, serving teams across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community.
+[AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, used across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community. We respect what the AG Grid team has built — it's a feat of engineering.
 
-This page compares Infinite Table and AG Grid so you can decide which fits your project. We'll be straightforward about where AG Grid is the stronger choice.
+The core difference is not price. It's how each grid relates to React.
+
+AG Grid was designed as a framework-agnostic rendering engine. Its React package is a wrapper — an adapter layer that translates between AG Grid's internal model and React components. The grid's state, lifecycle, and rendering happen outside React's reconciler. You configure it through a `gridOptions` object and interact with it through imperative API calls like `api.setColumnDefs()`, `api.refreshCells()`, and `api.getSelectedRows()`.
+
+Infinite Table was built for React from the start. There is no wrapper layer. Columns, sorting, grouping, and filtering are React props — controlled or uncontrolled, like any React component. Cell renderers are plain JSX. The grid participates in React's component tree, re-rendering when props change.
+
+## What this means in practice
+
+With AG Grid, you might write:
+
+```tsx
+// AG Grid: imperative API to update columns
+const onButtonClick = () => {
+  gridRef.current.api.setColumnDefs(newColumnDefs);
+  gridRef.current.api.refreshCells({ force: true });
+};
+```
+
+With Infinite Table, the same operation is a prop change:
+
+```tsx
+// Infinite Table: declarative React props
+const [columns, setColumns] = useState(initialColumns);
+
+const onButtonClick = () => {
+  setColumns(newColumns); // grid re-renders automatically
+};
+
+<DataSource<T> primaryKey="id" data={dataSource}>
+  <InfiniteTable<T> columns={columns} />
+</DataSource>
+```
+
+No ref, no imperative API — just React state. The same pattern you use for `<input value={...} onChange={...} />` works for the entire grid.
 
 ## Architecture
 
 | | Infinite Table | AG Grid |
 |---|---|---|
-| **Frameworks** | React | React, Angular, Vue, JavaScript |
+| **Built for** | React | Framework-agnostic (JS, Angular, Vue, React) |
+| **React integration** | Native — renders through React's reconciler | Wrapper — React adapter around internal DOM engine |
+| **API style** | Declarative props, controlled + uncontrolled | Grid-options object, imperative `api.*` calls |
+| **Cell renderers** | Plain JSX components | AG Grid component interface (React components supported via adapter) |
+| **State management** | Lives in React (useState, context, external stores) | Lives inside the grid; synced to React via callbacks |
 | **TypeScript** | Written in TypeScript, first-class types | Written in TypeScript, first-class types |
-| **API style** | Declarative, prop-driven | Imperative API + prop options |
-| **Rendering** | React component tree (no internal DOM engine) | Internal rendering engine; React wrapper dispatches to AG Grid's DOM layer |
 | **Virtualization** | Row + column | Row + column |
-
-Infinite Table renders through React's own reconciler — every cell is a React component. AG Grid uses its own internal rendering engine and wraps it for React. The practical difference: in Infinite Table, any React component works as a cell renderer without adapters. In AG Grid, custom cell renderers follow AG Grid's component interface, though React components are supported.
-
-AG Grid's architecture is why it supports multiple frameworks from a single codebase. If your organisation uses Angular or Vue alongside React, AG Grid lets you standardise on one grid.
 
 ## Feature Comparison
 
@@ -67,21 +98,19 @@ AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, t
 | **Free tier** | All features, footer displayed | Community edition (grouping/pivot excluded) |
 | **Support** | Email (paid license) | Zendesk (Enterprise license) |
 
-For a team of five front-end developers, Infinite Table costs $1,775/year vs roughly $4,995+/year for AG Grid Enterprise. The gap widens with larger teams.
-
 ## When AG Grid is the better choice
 
-- **Multi-framework projects.** If you need the same data grid in Angular, Vue, and React, AG Grid is the only option here — Infinite Table is React-only.
-- **The widest feature surface.** AG Grid Enterprise includes built-in charting integration, clipboard operations, Excel export, column tool panels, status bars, and a full server-side row model with partial store. If you need several of these, AG Grid covers them in one package.
-- **Enormous community and ecosystem.** With over 1M weekly npm downloads and 13k+ GitHub stars, AG Grid has deep community resources, Stack Overflow coverage, and third-party integrations.
-- **Non-React rendering performance.** AG Grid's internal rendering engine can outperform React reconciliation for extremely rapid, fine-grained cell updates in some scenarios, because it bypasses React's diffing.
+- **Multi-framework projects.** If you need the same data grid across Angular, Vue, and React codebases, AG Grid is the only option here — Infinite Table is React-only. AG Grid's framework-agnostic core is a strength when your organisation standardises on one grid across teams.
+- **The widest feature surface.** AG Grid Enterprise includes built-in charting, clipboard, Excel export, column tool panels, status bars, and a full server-side row model with partial store. If you need several of these, AG Grid covers them in one package.
+- **Enormous community and ecosystem.** With over 1M weekly npm downloads and 13k+ GitHub stars, AG Grid has deep community resources, Stack Overflow coverage, and third-party integrations. If you value ecosystem maturity, AG Grid is unmatched.
+- **You prefer the imperative API.** If your team already knows AG Grid's `api.*` pattern from other projects, or you prefer imperative control over the grid's state, AG Grid's model may feel more natural to you than a prop-driven React API.
 
 ## When Infinite Table is the better fit
 
-- **You only need React.** Infinite Table is built for React from the ground up. No framework-adapter layer means a simpler mental model and natural integration with React state management, Suspense, and concurrent features.
-- **You need grouping / pivoting / aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid gates them behind the Enterprise tier.
-- **Simpler licensing.** One price, one key for the whole team, no deployment license. AG Grid's licensing is also per-developer but starts at a higher price point.
-- **Declarative API.** Infinite Table is designed around React props and controlled/uncontrolled patterns rather than imperative grid API calls.
+- **You want the grid to feel like React.** Infinite Table's API is props, controlled state, and JSX — the same patterns you use in every other React component. No grid-options objects, no imperative API calls, no syncing grid state back to React. If your team thinks in React, Infinite Table fits that mental model.
+- **You need grouping, pivoting, and aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid gates them behind the Enterprise tier.
+- **You want a composable, smaller API surface.** Infinite Table favours function props over boolean flags, and controlled/uncontrolled variants over imperative setters. The API is designed to compose — fewer props that do more, rather than hundreds of configuration options.
+- **Simpler licensing.** One plan, one key for the whole team, no deployment license.
 
 ## Get started
 

--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -1,0 +1,95 @@
+---
+title: Infinite Table vs AG Grid
+description: A detailed comparison of Infinite Table and AG Grid for React. Architecture, features, pricing, and when AG Grid is the better choice.
+---
+
+[AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, serving teams across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community.
+
+This page compares Infinite Table and AG Grid so you can decide which fits your project. We'll be straightforward about where AG Grid is the stronger choice.
+
+## Architecture
+
+| | Infinite Table | AG Grid |
+|---|---|---|
+| **Frameworks** | React | React, Angular, Vue, JavaScript |
+| **TypeScript** | Written in TypeScript, first-class types | Written in TypeScript, first-class types |
+| **API style** | Declarative, prop-driven | Imperative API + prop options |
+| **Rendering** | React component tree (no internal DOM engine) | Internal rendering engine; React wrapper dispatches to AG Grid's DOM layer |
+| **Virtualization** | Row + column | Row + column |
+
+Infinite Table renders through React's own reconciler — every cell is a React component. AG Grid uses its own internal rendering engine and wraps it for React. The practical difference: in Infinite Table, any React component works as a cell renderer without adapters. In AG Grid, custom cell renderers follow AG Grid's component interface, though React components are supported.
+
+AG Grid's architecture is why it supports multiple frameworks from a single codebase. If your organisation uses Angular or Vue alongside React, AG Grid lets you standardise on one grid.
+
+## Feature Comparison
+
+| Feature | Infinite Table (free) | AG Grid Community (free) | AG Grid Enterprise (paid) |
+|---|---|---|---|
+| Sorting (single + multi) | Yes | Yes | Yes |
+| Column filtering | Yes | Yes | Yes |
+| Column resizing | Yes | Yes | Yes |
+| Column reordering | Yes | Yes | Yes |
+| Column pinning | Yes | Yes | Yes |
+| Column grouping (headers) | Yes | Yes | Yes |
+| Row grouping | Yes | — | Yes |
+| Aggregations | Yes | — | Yes |
+| Pivoting | Yes | — | Yes |
+| Tree data | Yes | — | Yes |
+| Master-detail | Yes | — | Yes |
+| Lazy loading | Yes | — | Yes (server-side row model) |
+| Live pagination | Yes | — | — |
+| Row + column virtualization | Yes | Yes | Yes |
+| Cell editing | Yes | Yes | Yes |
+| Cell selection | Yes | — | Yes (range selection) |
+| Row selection | Yes | Yes | Yes |
+| Context menus | Yes | — | Yes |
+| Keyboard navigation | Yes | Yes | Yes |
+| Theming (CSS variables) | Yes | Yes | Yes |
+| Excel export | — | — | Yes |
+| Clipboard | — | — | Yes |
+| Integrated charting | — | — | Yes |
+| Server-side row model | — (lazy loading + live pagination) | — | Yes |
+| Status bar / sidebar panels | — | — | Yes |
+
+<Note>
+
+AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, tree data, or master-detail. Those require AG Grid Enterprise. Infinite Table includes all of these in the free Community build (with a "Powered by Infinite Table" footer). A paid license key removes the footer.
+
+</Note>
+
+## Pricing
+
+| | Infinite Table | AG Grid Enterprise |
+|---|---|---|
+| **Starting price** | [$395/dev/year](https://infinite-table.com/pricing) | [~$999/dev/year](https://www.ag-grid.com/license-pricing) |
+| **Volume discount** | 5% at 3 devs, 10% at 5, 15% at 10 | Contact sales |
+| **Deployment license** | None required | None required |
+| **Free tier** | All features, footer displayed | Community edition (grouping/pivot excluded) |
+| **Support** | Email (paid license) | Zendesk (Enterprise license) |
+
+For a team of five front-end developers, Infinite Table costs $1,775/year vs roughly $4,995+/year for AG Grid Enterprise. The gap widens with larger teams.
+
+## When AG Grid is the better choice
+
+- **Multi-framework projects.** If you need the same data grid in Angular, Vue, and React, AG Grid is the only option here — Infinite Table is React-only.
+- **The widest feature surface.** AG Grid Enterprise includes built-in charting integration, clipboard operations, Excel export, column tool panels, status bars, and a full server-side row model with partial store. If you need several of these, AG Grid covers them in one package.
+- **Enormous community and ecosystem.** With over 1M weekly npm downloads and 13k+ GitHub stars, AG Grid has deep community resources, Stack Overflow coverage, and third-party integrations.
+- **Non-React rendering performance.** AG Grid's internal rendering engine can outperform React reconciliation for extremely rapid, fine-grained cell updates in some scenarios, because it bypasses React's diffing.
+
+## When Infinite Table is the better fit
+
+- **You only need React.** Infinite Table is built for React from the ground up. No framework-adapter layer means a simpler mental model and natural integration with React state management, Suspense, and concurrent features.
+- **You need grouping / pivoting / aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid gates them behind the Enterprise tier.
+- **Simpler licensing.** One price, one key for the whole team, no deployment license. AG Grid's licensing is also per-developer but starts at a higher price point.
+- **Declarative API.** Infinite Table is designed around React props and controlled/uncontrolled patterns rather than imperative grid API calls.
+
+## Get started
+
+<TerminalBlock>
+npm i @infinite-table/infinite-react
+</TerminalBlock>
+
+- [Getting Started guide](/docs/learn/getting-started)
+- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
+- [Pricing](/pricing)
+- [AG Grid official docs](https://www.ag-grid.com/react-data-grid/getting-started/)

--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -56,31 +56,31 @@ No ref, no imperative API — just React state. The same pattern you use for `<i
 
 | Feature | Infinite Table (free) | AG Grid Community (free) | AG Grid Enterprise (paid) |
 |---|---|---|---|
-| Sorting (single + multi) | Yes | Yes | Yes |
-| Column filtering | Yes | Yes | Yes |
-| Column resizing | Yes | Yes | Yes |
-| Column reordering | Yes | Yes | Yes |
-| Column pinning | Yes | Yes | Yes |
-| Column grouping (headers) | Yes | Yes | Yes |
-| Row grouping | Yes | — | Yes |
-| Aggregations | Yes | — | Yes |
-| Pivoting | Yes | — | Yes |
-| Tree data | Yes | — | Yes |
-| Master-detail | Yes | — | Yes |
-| Lazy loading | Yes | — | Yes (server-side row model) |
-| Live pagination | Yes | — | — |
-| Row + column virtualization | Yes | Yes | Yes |
-| Cell editing | Yes | Yes | Yes |
-| Cell selection | Yes | — | Yes (range selection) |
-| Row selection | Yes | Yes | Yes |
-| Context menus | Yes | — | Yes |
-| Keyboard navigation | Yes | Yes | Yes |
-| Theming (CSS variables) | Yes | Yes | Yes |
-| Excel export | — | — | Yes |
-| Clipboard | — | — | Yes |
-| Integrated charting | — | — | Yes |
-| Server-side row model | — (lazy loading + live pagination) | — | Yes |
-| Status bar / sidebar panels | — | — | Yes |
+| Sorting (single + multi) | ✅ | ✅ | ✅ |
+| Column filtering | ✅ | ✅ | ✅ |
+| Column resizing | ✅ | ✅ | ✅ |
+| Column reordering | ✅ | ✅ | ✅ |
+| Column pinning | ✅ | ✅ | ✅ |
+| Column grouping (headers) | ✅ | ✅ | ✅ |
+| Row grouping | ✅ | 🔴 | ✅ |
+| Aggregations | ✅ | 🔴 | ✅ |
+| Pivoting | ✅ | 🔴 | ✅ |
+| Tree data | ✅ | 🔴 | ✅ |
+| Master-detail | ✅ | 🔴 | ✅ |
+| Lazy loading | ✅ | 🔴 | ✅ (server-side row model) |
+| Live pagination | ✅ | 🔴 | ✅ |
+| Row + column virtualization | ✅ | ✅ | ✅ |
+| Cell editing | ✅ | ✅ | ✅ |
+| Cell selection | ✅ | 🔴 | ✅ (range selection) |
+| Row selection | ✅ | ✅ | ✅ |
+| Context menus | ✅ | 🔴 | ✅ |
+| Keyboard navigation | ✅ | ✅ | ✅ |
+| Theming (CSS variables) | ✅ | ✅ | ✅ |
+| Excel export | 🔴 | 🔴 | ✅ |
+| Clipboard | 🔴 | 🔴 | ✅ |
+| Integrated charting | 🔴 | 🔴 | ✅ |
+| Server-side row model | ✅ | 🔴 | ✅ |
+| Status bar / sidebar panels | 🔴 | 🔴 | ✅ |
 
 <Note>
 
@@ -112,13 +112,29 @@ AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, t
 - **You want a composable, smaller API surface.** Infinite Table favours function props over boolean flags, and controlled/uncontrolled variants over imperative setters. The API is designed to compose — fewer props that do more, rather than hundreds of configuration options.
 - **Simpler licensing.** One plan, one key for the whole team, no deployment license.
 
-## Get started
 
-<TerminalBlock>
-npm i @infinite-table/infinite-react
-</TerminalBlock>
+<HeroCards>
+<YouWillLearnCard title="Getting Started" path="/docs/learn/getting-started">
+Install the package, render your first DataGrid, and learn how `<DataSource />` and `<InfiniteTable />` work together.
+</YouWillLearnCard>
+<YouWillLearnCard title="Grouping and pivoting" path="/docs/learn/grouping-and-pivoting">
+The features AG Grid Community leaves out — included here without an Enterprise license.
+</YouWillLearnCard>
+</HeroCards>
 
-- [Getting Started guide](/docs/learn/getting-started)
-- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
-- [Pricing](/pricing)
-- [AG Grid official docs](https://www.ag-grid.com/react-data-grid/getting-started/)
+<HeroCards>
+<YouWillLearnCard title="Pricing" path="/pricing">
+Use Infinite Table free with a footer, or buy a license to remove it and get email support.
+</YouWillLearnCard>
+<YouWillLearnCard title="AG Grid docs" path="https://www.ag-grid.com/react-data-grid/getting-started/" newTab>
+Read AG Grid's official React getting started guide.
+</YouWillLearnCard>
+</HeroCards>
+
+## Help us keep this comparison up-to-date
+
+This page is our reading of AG Grid's public docs and pricing as of mid-2026. We want it to stay accurate. If you work on AG Grid — or you've spotted something that's wrong, outdated, or missing context — please tell us. We will update the page.
+
+- [Edit this page on GitHub](https://github.com/infinite-table/infinite-react/edit/master/www/content/docs/learn/compare/ag-grid.page.md) and open a pull request
+- [File a correction issue](https://github.com/infinite-table/infinite-react/issues/new?template=compare_page_correction.md&title=Compare%20page%20correction%3A%20AG%20Grid)
+- Email [admin@infinite-table.com](mailto:admin@infinite-table.com?subject=Compare%20page%20correction%3A%20AG%20Grid) with the URL and what should change

--- a/www/content/docs/learn/compare/index.page.md
+++ b/www/content/docs/learn/compare/index.page.md
@@ -3,29 +3,32 @@ title: Compare React DataGrids
 description: Honest comparison of Infinite Table against AG Grid, TanStack Table, and MUI X Data Grid. Find the right React data grid for your project.
 ---
 
-Choosing a React data grid is a consequential decision — it shapes your bundle, your API surface, and how much time you spend fighting the component instead of shipping features.
+Most data grids were not built for React. They were built for the browser — or for multiple frameworks at once — and later wrapped with a React adapter. The result is an API that feels foreign: grid-options objects, imperative method calls, callback registrations instead of props.
 
-This section offers honest, side-by-side comparisons of Infinite Table with three popular alternatives. We cover architecture, feature availability, licensing, and — just as importantly — where the other tool is the better fit.
+Infinite Table was built for React from the ground up. Columns are props. Sorting, grouping, and filtering are controlled or uncontrolled values — the same pattern you use for an `<input>`. Cell renderers are plain JSX. State lives in React, not inside the grid. When you change a prop, the grid re-renders. No `.api.setColumnDefs()`, no `ref.current.resetRowHeights()` — just React.
+
+This section compares Infinite Table with three popular alternatives. We cover how each one integrates with React, what features ship built-in, and — just as importantly — when the other tool is the better fit.
 
 ## Comparisons
 
-- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set, higher price point.
-- [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed table logic library. Maximum flexibility; you build the UI.
-- [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem with tiered paid plans for advanced features.
+- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set — but its API was designed for vanilla JS and Angular first, then wrapped for React.
+- [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed logic library. Total rendering control — but you build the UI, the virtualization, and the keyboard navigation yourself.
+- [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem. Excellent MUI integration — but grouping and pivoting require the Premium tier.
 
 ## Quick Comparison
 
 | | Infinite Table | AG Grid | TanStack Table | MUI X Data Grid |
 |---|---|---|---|---|
-| **Framework** | React only | React, Angular, Vue, JS | React, Vue, Solid, Svelte (headless) | React only |
-| **Rendering** | Full component | Full component | Headless (logic only) | Full component |
+| **Built for React** | Yes — from the ground up | No — framework-agnostic core with React wrapper | Headless — framework-agnostic hooks | Yes — React only |
+| **API style** | Declarative props, controlled + uncontrolled | Grid-options object, imperative API | Headless hooks, you provide all JSX | Declarative props, controlled + uncontrolled |
+| **Cell renderers** | JSX components | AG Grid component interface (React supported) | You build all rendering | JSX components |
+| **Frameworks** | React | React, Angular, Vue, JS | React, Vue, Solid, Svelte | React |
 | **Virtualization** | Row + column | Row + column | BYO (separate package) | Row (column in Pro+) |
-| **Grouping** | Free | Enterprise license | Free (logic only) | Premium plan |
-| **Pivoting** | Free | Enterprise license | Free (logic only) | Premium plan |
-| **Aggregations** | Free | Enterprise license | Free (logic only) | Premium plan |
-| **Tree data** | Free | Enterprise license | Free (logic only) | Pro plan |
+| **Grouping** | Included (free) | Enterprise license | Logic only (free) | Premium plan ($599/dev/yr) |
+| **Pivoting** | Included (free) | Enterprise license | Logic only (free) | Premium plan ($599/dev/yr) |
+| **Tree data** | Included (free) | Enterprise license | Logic only (free) | Pro plan ($299/dev/yr) |
 | **License** | Free with footer; paid removes footer | Community MIT; Enterprise proprietary | MIT | Community MIT; Pro/Premium/Enterprise proprietary |
-| **Starting price** | $395/dev/year | ~$999/dev/year (Enterprise) | Free | $299/dev/year (Pro) |
+| **Paid license** | [$395/dev/year](https://infinite-table.com/pricing) | [~$999/dev/year](https://www.ag-grid.com/license-pricing) | Free | [$299/dev/year (Pro)](https://mui.com/pricing/) |
 
 <Note>
 
@@ -35,15 +38,15 @@ Feature availability is based on each product's official documentation as of mid
 
 ## How to decide
 
-**Pick Infinite Table** if you are building a React app that needs grouping, pivoting, or aggregations without paying for an enterprise license — and you want a fully rendered, TypeScript-first component out of the box.
+**Pick Infinite Table** if you want a data grid that feels like a native React component — declarative props, controlled state, JSX renderers — with grouping, pivoting, and aggregations included out of the box, no enterprise license required.
 
-**Pick AG Grid** if you need multi-framework support, the widest possible feature set (charting, server-side row model, clipboard integrations), or you are standardising on a single grid across Angular, Vue, and React projects.
+**Pick AG Grid** if you need multi-framework support (Angular, Vue, and React under one grid), the widest possible feature surface (charting, clipboard, server-side row model), or you prefer an imperative API you already know from other AG Grid projects.
 
-**Pick TanStack Table** if you want full control over rendering, are comfortable building your own UI layer and wiring up virtualization, or you need a framework-agnostic logic library for a lightweight table.
+**Pick TanStack Table** if you want total control over rendering and are prepared to build your own UI layer, virtualization, keyboard navigation, and accessibility from scratch. Best for design-system component libraries or lightweight tables that don't need complex features.
 
-**Pick MUI X Data Grid** if your application is already built on Material UI and you value visual consistency with MUI's design system, or you need the broader MUI X component suite (date pickers, charts, tree view) under a single license.
+**Pick MUI X Data Grid** if your application is already built on Material UI and you value automatic theme integration with MUI's design system, or you need the broader MUI X component suite (date pickers, charts, tree view) under a single license.
 
-## Get started with Infinite Table
+## Get started
 
 <TerminalBlock>
 npm i @infinite-table/infinite-react

--- a/www/content/docs/learn/compare/index.page.md
+++ b/www/content/docs/learn/compare/index.page.md
@@ -5,7 +5,7 @@ description: Honest comparison of Infinite Table against AG Grid, TanStack Table
 
 Most data grids were not built for React. They were built for the browser — or for multiple frameworks at once — and later wrapped with a React adapter. The result is an API that feels foreign: grid-options objects, imperative method calls, callback registrations instead of props.
 
-Infinite Table was built for React from the ground up. Columns are props. Sorting, grouping, and filtering are controlled or uncontrolled values — the same pattern you use for an `<input>`. Cell renderers are plain JSX. State lives in React, not inside the grid. When you change a prop, the grid re-renders. No `.api.setColumnDefs()`, no `ref.current.resetRowHeights()` — just React.
+Infinite Table was built for React from the ground up. Columns are props. Sorting, grouping, and filtering are controlled or uncontrolled values — the same pattern you use for an `<input>`. Cell renderers are plain JSX. State lives in React, not inside the grid. When you change a prop, the grid re-renders. You're not forced to use APIs unless you want to — just React.
 
 This section compares Infinite Table with three popular alternatives. We cover how each one integrates with React, what features ship built-in, and — just as importantly — when the other tool is the better fit.
 
@@ -48,9 +48,45 @@ Feature availability is based on each product's official documentation as of mid
 
 ## Get started
 
+Install Infinite Table from npm. The package includes everything: grouping, pivoting, tree data, and the rest of the features in the table above — no enterprise package or license required.
+
 <TerminalBlock>
 npm i @infinite-table/infinite-react
 </TerminalBlock>
 
-- [Getting Started guide](/docs/learn/getting-started)
-- [Pricing](/pricing)
+From there, follow the Getting Started guide for a first grid, or open the comparison that matches the tool you're evaluating.
+
+<HeroCards>
+<YouWillLearnCard title="Getting Started" path="/docs/learn/getting-started">
+Install the package, render your first DataGrid, and learn how `<DataSource />` and `<InfiniteTable />` work together.
+</YouWillLearnCard>
+<YouWillLearnCard title="Pricing" path="/pricing">
+Use Infinite Table free with a footer, or buy a license to remove it and get email support.
+</YouWillLearnCard>
+</HeroCards>
+
+<HeroCards>
+<YouWillLearnCard title="vs AG Grid" path="/docs/learn/compare/ag-grid">
+React-native props versus a framework-agnostic wrapper, plus which features sit behind AG Grid Enterprise.
+</YouWillLearnCard>
+<YouWillLearnCard title="vs TanStack Table" path="/docs/learn/compare/tanstack-table">
+A rendered, virtualized DataGrid versus a headless table library you assemble yourself.
+</YouWillLearnCard>
+</HeroCards>
+
+<HeroCards>
+<YouWillLearnCard title="vs MUI X Data Grid" path="/docs/learn/compare/mui-x-data-grid">
+What ships in Infinite Table's free build versus MUI X Community, Pro, and Premium.
+</YouWillLearnCard>
+<YouWillLearnCard title="Grouping and pivoting" path="/docs/learn/grouping-and-pivoting">
+The features most often gated on other grids — included here without an enterprise tier.
+</YouWillLearnCard>
+</HeroCards>
+
+## Help us keep these comparisons up-to-date
+
+These pages are our reading of each product's public documentation and pricing as of mid-2026. We want them to stay accurate. If you work on AG Grid, TanStack Table, or MUI X — or you've spotted something that's wrong, outdated, or missing context — please tell us. We will update the page.
+
+- [File a correction issue](https://github.com/infinite-table/infinite-react/issues/new?template=compare_page_correction.md&title=Compare%20page%20correction%3A%20)
+- [Edit the source on GitHub](https://github.com/infinite-table/infinite-react/tree/master/www/content/docs/learn/compare) and open a pull request
+- Email [admin@infinite-table.com](mailto:admin@infinite-table.com?subject=Compare%20page%20correction) with the page URL and what should change

--- a/www/content/docs/learn/compare/index.page.md
+++ b/www/content/docs/learn/compare/index.page.md
@@ -1,0 +1,53 @@
+---
+title: Compare React DataGrids
+description: Honest comparison of Infinite Table against AG Grid, TanStack Table, and MUI X Data Grid. Find the right React data grid for your project.
+---
+
+Choosing a React data grid is a consequential decision — it shapes your bundle, your API surface, and how much time you spend fighting the component instead of shipping features.
+
+This section offers honest, side-by-side comparisons of Infinite Table with three popular alternatives. We cover architecture, feature availability, licensing, and — just as importantly — where the other tool is the better fit.
+
+## Comparisons
+
+- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set, higher price point.
+- [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed table logic library. Maximum flexibility; you build the UI.
+- [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem with tiered paid plans for advanced features.
+
+## Quick Comparison
+
+| | Infinite Table | AG Grid | TanStack Table | MUI X Data Grid |
+|---|---|---|---|---|
+| **Framework** | React only | React, Angular, Vue, JS | React, Vue, Solid, Svelte (headless) | React only |
+| **Rendering** | Full component | Full component | Headless (logic only) | Full component |
+| **Virtualization** | Row + column | Row + column | BYO (separate package) | Row (column in Pro+) |
+| **Grouping** | Free | Enterprise license | Free (logic only) | Premium plan |
+| **Pivoting** | Free | Enterprise license | Free (logic only) | Premium plan |
+| **Aggregations** | Free | Enterprise license | Free (logic only) | Premium plan |
+| **Tree data** | Free | Enterprise license | Free (logic only) | Pro plan |
+| **License** | Free with footer; paid removes footer | Community MIT; Enterprise proprietary | MIT | Community MIT; Pro/Premium/Enterprise proprietary |
+| **Starting price** | $395/dev/year | ~$999/dev/year (Enterprise) | Free | $299/dev/year (Pro) |
+
+<Note>
+
+Feature availability is based on each product's official documentation as of mid-2026. Always verify on the vendor's site before making a purchasing decision.
+
+</Note>
+
+## How to decide
+
+**Pick Infinite Table** if you are building a React app that needs grouping, pivoting, or aggregations without paying for an enterprise license — and you want a fully rendered, TypeScript-first component out of the box.
+
+**Pick AG Grid** if you need multi-framework support, the widest possible feature set (charting, server-side row model, clipboard integrations), or you are standardising on a single grid across Angular, Vue, and React projects.
+
+**Pick TanStack Table** if you want full control over rendering, are comfortable building your own UI layer and wiring up virtualization, or you need a framework-agnostic logic library for a lightweight table.
+
+**Pick MUI X Data Grid** if your application is already built on Material UI and you value visual consistency with MUI's design system, or you need the broader MUI X component suite (date pickers, charts, tree view) under a single license.
+
+## Get started with Infinite Table
+
+<TerminalBlock>
+npm i @infinite-table/infinite-react
+</TerminalBlock>
+
+- [Getting Started guide](/docs/learn/getting-started)
+- [Pricing](/pricing)

--- a/www/content/docs/learn/compare/mui-x-data-grid.page.md
+++ b/www/content/docs/learn/compare/mui-x-data-grid.page.md
@@ -1,24 +1,36 @@
 ---
 title: Infinite Table vs MUI X Data Grid
-description: A detailed comparison of Infinite Table and MUI X Data Grid. Features, licensing tiers, pricing, and when MUI X Data Grid is the better choice.
+description: A detailed comparison of Infinite Table and MUI X Data Grid. React-native design approaches, features across tiers, and when MUI X Data Grid is the better choice.
 ---
 
-[MUI X Data Grid](https://mui.com/x/react-data-grid/) is a React data grid component from the Material UI team. It's part of the broader MUI X suite (date pickers, charts, tree view) and follows Material Design conventions. Like AG Grid, it uses a tiered open-core model: Community (MIT), Pro, Premium, and Enterprise.
+[MUI X Data Grid](https://mui.com/x/react-data-grid/) is a React data grid from the Material UI team. It's part of the broader MUI X suite (date pickers, charts, tree view) and follows Material Design conventions. Like Infinite Table, it's React-only and uses a declarative, prop-driven API.
 
-This page compares Infinite Table with MUI X Data Grid so you can make an informed decision.
+These two grids have more in common architecturally than either has with AG Grid or TanStack Table. Both render through React, both use props and controlled state, both support JSX cell renderers. The differences are in design-system coupling, feature availability across tiers, and how each grid's API is structured.
+
+## Where they diverge
+
+**Design-system coupling.** MUI X Data Grid is built on Material UI. It inherits your MUI theme tokens — palette, spacing, typography — automatically. This is a major advantage if your app already uses MUI, and a friction point if it doesn't, because MUI's styling system (`@emotion`, theme provider, `sx` prop) comes along as dependencies.
+
+Infinite Table is design-system agnostic. Theming is done through CSS variables — you can integrate with Tailwind, vanilla CSS, or any design system without extra dependencies. There's no coupling to a specific component library.
+
+**Feature availability.** MUI X uses a four-tier model: Community (free), Pro ($299/dev/yr), Premium ($599/dev/yr), and Enterprise ($1,399/dev/yr). Core features like column resizing, pinning, and tree data require at least Pro. Grouping, pivoting, and aggregations require Premium.
+
+Infinite Table includes all of these in the free Community build. A "Powered by Infinite Table" footer is displayed; a [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes it.
+
+**Data layer separation.** Infinite Table splits data management and rendering into two React components — `<DataSource>` and `<InfiniteTable>`. The `<DataSource>` handles fetching, sorting, grouping, pivoting, and filtering; the `<InfiniteTable>` handles rendering. You can even use `<DataSource>` with your own custom component. MUI X Data Grid is a single component that handles both data and rendering internally.
 
 ## Architecture
 
 | | Infinite Table | MUI X Data Grid |
 |---|---|---|
 | **Framework** | React | React |
-| **Design system** | Framework-agnostic; theming via CSS variables | Material UI (MUI); theming via MUI's theme system |
+| **Design system** | Agnostic — CSS variables | Material UI — MUI theme system |
+| **Component model** | Two components: `<DataSource>` + `<InfiniteTable>` | Single `<DataGrid>` / `<DataGridPro>` / `<DataGridPremium>` component |
+| **API style** | Declarative props, controlled + uncontrolled | Declarative props, controlled + uncontrolled |
+| **Cell renderers** | JSX components via column `render` prop | JSX components via `renderCell` slot |
 | **TypeScript** | Written in TypeScript | Written in TypeScript |
 | **Virtualization** | Row + column | Row virtualization; column virtualization in Pro+ |
-| **API style** | Declarative, prop-driven (controlled + uncontrolled) | Declarative, prop-driven (controlled + uncontrolled) |
-| **Package** | Single package, all features | Separate packages per tier (`@mui/x-data-grid`, `@mui/x-data-grid-pro`, `@mui/x-data-grid-premium`) |
-
-Both are React-only, TypeScript-first data grids with declarative APIs. The biggest architectural difference is the design system coupling: MUI X Data Grid is designed to work within the Material UI ecosystem. If your app already uses MUI, the Data Grid inherits your theme tokens, spacing, and typography automatically. Infinite Table is design-system agnostic and uses CSS variables for theming.
+| **Packages** | Single package, all features | Separate packages per tier |
 
 ## Feature Comparison
 
@@ -46,13 +58,12 @@ Both are React-only, TypeScript-first data grids with declarative APIs. The bigg
 | Context menus | Yes | — | — | — |
 | Excel export | — | — | — | Yes |
 | Clipboard (copy/paste) | — | — | — | Yes |
-| Pagination > 100 rows/page | — | — | Yes | Yes |
 
 <Note>
 
 MUI X uses a tiered model: row grouping, pivoting, aggregations, and cell selection require the Premium plan ($599/dev/year). Column resizing, pinning, reordering, tree data, and master-detail require at least Pro ($299/dev/year). Feature details are from the [MUI pricing page](https://mui.com/pricing/).
 
-Infinite Table includes all of these features in the free Community build (a "Powered by Infinite Table" footer is displayed). A paid license ($395/dev/year) removes the footer.
+Infinite Table includes all of these features in the free Community build.
 
 </Note>
 
@@ -67,27 +78,22 @@ Infinite Table includes all of these features in the free Community build (a "Po
 | **Deployment license** | None | None | None | None |
 | **Support** | Email (paid) | Community | Priority over Community | Priority over Pro |
 
-To match Infinite Table's feature set (grouping, pivoting, aggregations, cell selection), you need MUI X Premium at $599/dev/year. Infinite Table offers these for free — or at $395/dev/year if you want to remove the footer.
-
-For a team of five developers needing pivoting:
-- Infinite Table: $1,775/year (or $0 with footer)
-- MUI X Premium: $2,995/year
-
 ## When MUI X Data Grid is the better choice
 
-- **You're already in the MUI ecosystem.** If your app uses Material UI, MUI X Data Grid inherits your MUI theme, spacing, palette, and typography with zero configuration. Infinite Table uses its own CSS variables and won't automatically pick up your MUI theme tokens.
-- **You need the full MUI X suite.** MUI X includes date pickers, charts, tree view, and a scheduler under a single license. If you need multiple MUI X components, a Pro or Premium license covers them all — better value than paying separately for each tool.
-- **You value Material Design consistency.** The Data Grid follows Material Design patterns by default. If your design spec is Material Design, MUI X Data Grid is a natural fit.
-- **Community size.** MUI has a very large user community — Material UI's npm downloads are in the millions per week. More community resources, more Stack Overflow answers, more third-party tutorials.
-- **Column-level features at the Pro tier.** If you need column resizing, pinning, reordering, and tree data but not grouping/pivoting, MUI X Pro at $299/dev/year covers those features. Infinite Table offers the same features free (with footer) or at $395/dev/year (without), so MUI X Pro is comparable in price while covering non-grid MUI X components too.
+- **You're already in the MUI ecosystem.** If your app uses Material UI, MUI X Data Grid inherits your MUI theme automatically — palette, spacing, typography, dark mode — with zero configuration. Infinite Table uses CSS variables and won't pick up MUI theme tokens automatically.
+- **You need the full MUI X suite.** MUI X includes date pickers, charts, tree view, and a scheduler under a single license. If you need multiple MUI X components, a Pro or Premium license covers them all.
+- **Material Design consistency.** The Data Grid follows Material Design patterns by default. If your design spec is Material Design, MUI X is the most natural fit.
+- **Large community.** MUI has a very large user community — millions of weekly npm downloads for Material UI. More community resources, tutorials, and third-party integrations.
+- **Column-level features at the Pro tier.** If you need column resizing, pinning, reordering, and tree data but not grouping or pivoting, MUI X Pro at $299/dev/year covers those features along with all other MUI X Pro components.
 
 ## When Infinite Table is the better fit
 
-- **You need grouping, pivoting, and aggregations without paying for Premium.** These are free in Infinite Table's Community build. MUI X requires the Premium plan ($599/dev/year) for the same features.
-- **You're not using Material UI.** If your app uses Tailwind, vanilla CSS, or another design system, MUI X Data Grid brings along the MUI styling system as a dependency. Infinite Table uses plain CSS variables and works with any styling approach.
+- **You need grouping, pivoting, and aggregations without the Premium tier.** These are free in Infinite Table's Community build. MUI X requires Premium ($599/dev/year) for the same features.
+- **You're not using Material UI.** If your app uses Tailwind, vanilla CSS, or another design system, MUI X Data Grid brings along the MUI styling system as a dependency. Infinite Table uses plain CSS variables and works with any styling approach — no extra dependencies, no theme provider wrappers.
+- **Data layer separation.** Infinite Table's `<DataSource>` / `<InfiniteTable>` split gives you a clean separation between data management (fetching, sorting, grouping, pivoting, filtering) and rendering. You can even replace `<InfiniteTable>` with your own component and keep the data layer.
 - **Column virtualization on the free tier.** Infinite Table virtualizes both rows and columns by default. MUI X Community only virtualizes rows up to 100 rows; column virtualization and unlimited row virtualization require Pro.
 - **Live pagination and context menus.** Infinite Table includes built-in live pagination and context menus. MUI X does not offer equivalents at any tier.
-- **Simpler licensing model.** Infinite Table has one plan. MUI X has four tiers where features are spread across Community, Pro, Premium, and Enterprise — you need to check which tier covers each feature you need.
+- **Simpler licensing model.** Infinite Table has one plan with all features. MUI X has four tiers — you need to cross-reference the pricing page to see which tier covers each feature you need.
 
 ## Get started
 

--- a/www/content/docs/learn/compare/mui-x-data-grid.page.md
+++ b/www/content/docs/learn/compare/mui-x-data-grid.page.md
@@ -15,7 +15,7 @@ Infinite Table is design-system agnostic. Theming is done through CSS variables 
 
 **Feature availability.** MUI X uses a four-tier model: Community (free), Pro ($299/dev/yr), Premium ($599/dev/yr), and Enterprise ($1,399/dev/yr). Core features like column resizing, pinning, and tree data require at least Pro. Grouping, pivoting, and aggregations require Premium.
 
-Infinite Table includes all of these in the free Community build. A "Powered by Infinite Table" footer is displayed; a [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes it.
+Infinite Table includes all of these in the package (only one package, no separate community and enterprise packages). A "Powered by Infinite Table" footer is displayed; a [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes it.
 
 **Data layer separation.** Infinite Table splits data management and rendering into two React components — `<DataSource>` and `<InfiniteTable>`. The `<DataSource>` handles fetching, sorting, grouping, pivoting, and filtering; the `<InfiniteTable>` handles rendering. You can even use `<DataSource>` with your own custom component. MUI X Data Grid is a single component that handles both data and rendering internally.
 
@@ -36,28 +36,28 @@ Infinite Table includes all of these in the free Community build. A "Powered by 
 
 | Feature | Infinite Table (free) | MUI X Community (free) | MUI X Pro ($299/dev/yr) | MUI X Premium ($599/dev/yr) |
 |---|---|---|---|---|
-| Sorting (single + multi) | Yes | Yes (single) | Yes (multi) | Yes (multi) |
-| Column filtering | Yes | Yes (single) | Yes (multi) | Yes (multi) |
-| Column resizing | Yes | — | Yes | Yes |
-| Column reordering | Yes | — | Yes | Yes |
-| Column pinning | Yes | — | Yes | Yes |
-| Column grouping (headers) | Yes | Yes | Yes | Yes |
-| Row grouping | Yes | — | — | Yes |
-| Aggregations | Yes | — | — | Yes |
-| Pivoting | Yes | — | — | Yes |
-| Tree data | Yes | — | Yes | Yes |
-| Master-detail | Yes | — | Yes | Yes |
-| Row virtualization | Yes | Yes (≤100 rows) | Yes | Yes |
-| Column virtualization | Yes | — | Yes | Yes |
-| Cell editing | Yes | Yes | Yes | Yes |
-| Cell selection | Yes | — | — | Yes |
-| Row selection | Yes | Yes | Yes | Yes |
-| Keyboard navigation | Yes | Yes | Yes | Yes |
-| Lazy loading | Yes | — | Yes (server-side) | Yes |
-| Live pagination | Yes | — | — | — |
-| Context menus | Yes | — | — | — |
-| Excel export | — | — | — | Yes |
-| Clipboard (copy/paste) | — | — | — | Yes |
+| Sorting (single + multi) | ✅ | ✅ (single) | ✅ (multi) | ✅ (multi) |
+| Column filtering | ✅ | ✅ (single) | ✅ (multi) | ✅ (multi) |
+| Column resizing | ✅ | 🔴 | ✅ | ✅ |
+| Column reordering | ✅ | 🔴 | ✅ | ✅ |
+| Column pinning | ✅ | 🔴 | ✅ | ✅ |
+| Column grouping (headers) | ✅ | ✅ | ✅ | ✅ |
+| Row grouping | ✅ | 🔴 | 🔴 | ✅ |
+| Aggregations | ✅ | 🔴 | 🔴 | ✅ |
+| Pivoting | ✅ | 🔴 | 🔴 | ✅ |
+| Tree data | ✅ | 🔴 | ✅ | ✅ |
+| Master-detail | ✅ | 🔴 | ✅ | ✅ |
+| Row virtualization | ✅ | ✅  | ✅ | ✅ |
+| Column virtualization | ✅ | 🔴 | ✅ | ✅ |
+| Cell editing | ✅ | ✅ | ✅ | ✅ |
+| Cell selection | ✅ | 🔴 | 🔴 | ✅ |
+| Row selection | ✅ | ✅ | ✅ | ✅ |
+| Keyboard navigation | ✅ | ✅ | ✅ | ✅ |
+| Lazy loading | ✅ | 🔴 | ✅ (server-side) | ✅ |
+| Live pagination | ✅ | 🔴 | 🔴 | 🔴 |
+| Context menus | ✅ | 🔴 | 🔴 | 🔴 |
+| Excel export | 🔴 | 🔴 | 🔴 | ✅ |
+| Clipboard (copy/paste) | 🔴 | 🔴 | 🔴 | ✅ |
 
 <Note>
 
@@ -72,9 +72,9 @@ Infinite Table includes all of these features in the free Community build.
 | | Infinite Table | MUI X Pro | MUI X Premium | MUI X Enterprise |
 |---|---|---|---|---|
 | **Price** | [$395/dev/year](https://infinite-table.com/pricing) | [$299/dev/year](https://mui.com/pricing/) | [$599/dev/year](https://mui.com/pricing/) | [$1,399/dev/year](https://mui.com/pricing/) |
-| **Grouping + pivoting** | Included (free) | — | Included | Included |
-| **Tree data + master-detail** | Included (free) | Included | Included | Included |
-| **Column resizing + pinning** | Included (free) | Included | Included | Included |
+| **Grouping + pivoting** | ✅ (free) | 🔴 | ✅ | ✅ |
+| **Tree data + master-detail** | ✅ (free) | ✅ | ✅ | ✅ |
+| **Column resizing + pinning** | ✅ (free) | ✅ | ✅ | ✅ |
 | **Deployment license** | None | None | None | None |
 | **Support** | Email (paid) | Community | Priority over Community | Priority over Pro |
 
@@ -95,14 +95,29 @@ Infinite Table includes all of these features in the free Community build.
 - **Live pagination and context menus.** Infinite Table includes built-in live pagination and context menus. MUI X does not offer equivalents at any tier.
 - **Simpler licensing model.** Infinite Table has one plan with all features. MUI X has four tiers — you need to cross-reference the pricing page to see which tier covers each feature you need.
 
-## Get started
 
-<TerminalBlock>
-npm i @infinite-table/infinite-react
-</TerminalBlock>
+<HeroCards>
+<YouWillLearnCard title="Getting Started" path="/docs/learn/getting-started">
+Install the package, render your first DataGrid, and learn how `<DataSource />` and `<InfiniteTable />` work together.
+</YouWillLearnCard>
+<YouWillLearnCard title="Theming with CSS variables" path="/docs/learn/theming/css-variables">
+Theme Infinite Table without a Material UI theme provider — CSS variables only.
+</YouWillLearnCard>
+</HeroCards>
 
-- [Getting Started guide](/docs/learn/getting-started)
-- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
-- [Theming with CSS variables](/docs/learn/theming/css-variables)
-- [Pricing](/pricing)
-- [MUI X Data Grid official docs](https://mui.com/x/react-data-grid/)
+<HeroCards>
+<YouWillLearnCard title="Pricing" path="/pricing">
+Use Infinite Table free with a footer, or buy a license to remove it and get email support.
+</YouWillLearnCard>
+<YouWillLearnCard title="MUI X Data Grid docs" path="https://mui.com/x/react-data-grid/" newTab>
+Read MUI X Data Grid's official documentation.
+</YouWillLearnCard>
+</HeroCards>
+
+## Help us keep this comparison up-to-date
+
+This page is our reading of MUI X Data Grid's public docs and [pricing page](https://mui.com/pricing/) as of mid-2026. We want it to stay accurate. If you work on MUI X — or you've spotted something that's wrong, outdated, or missing context — please tell us. We will update the page.
+
+- [Edit this page on GitHub](https://github.com/infinite-table/infinite-react/edit/master/www/content/docs/learn/compare/mui-x-data-grid.page.md) and open a pull request
+- [File a correction issue](https://github.com/infinite-table/infinite-react/issues/new?template=compare_page_correction.md&title=Compare%20page%20correction%3A%20MUI%20X%20Data%20Grid)
+- Email [admin@infinite-table.com](mailto:admin@infinite-table.com?subject=Compare%20page%20correction%3A%20MUI%20X%20Data%20Grid) with the URL and what should change

--- a/www/content/docs/learn/compare/mui-x-data-grid.page.md
+++ b/www/content/docs/learn/compare/mui-x-data-grid.page.md
@@ -1,0 +1,102 @@
+---
+title: Infinite Table vs MUI X Data Grid
+description: A detailed comparison of Infinite Table and MUI X Data Grid. Features, licensing tiers, pricing, and when MUI X Data Grid is the better choice.
+---
+
+[MUI X Data Grid](https://mui.com/x/react-data-grid/) is a React data grid component from the Material UI team. It's part of the broader MUI X suite (date pickers, charts, tree view) and follows Material Design conventions. Like AG Grid, it uses a tiered open-core model: Community (MIT), Pro, Premium, and Enterprise.
+
+This page compares Infinite Table with MUI X Data Grid so you can make an informed decision.
+
+## Architecture
+
+| | Infinite Table | MUI X Data Grid |
+|---|---|---|
+| **Framework** | React | React |
+| **Design system** | Framework-agnostic; theming via CSS variables | Material UI (MUI); theming via MUI's theme system |
+| **TypeScript** | Written in TypeScript | Written in TypeScript |
+| **Virtualization** | Row + column | Row virtualization; column virtualization in Pro+ |
+| **API style** | Declarative, prop-driven (controlled + uncontrolled) | Declarative, prop-driven (controlled + uncontrolled) |
+| **Package** | Single package, all features | Separate packages per tier (`@mui/x-data-grid`, `@mui/x-data-grid-pro`, `@mui/x-data-grid-premium`) |
+
+Both are React-only, TypeScript-first data grids with declarative APIs. The biggest architectural difference is the design system coupling: MUI X Data Grid is designed to work within the Material UI ecosystem. If your app already uses MUI, the Data Grid inherits your theme tokens, spacing, and typography automatically. Infinite Table is design-system agnostic and uses CSS variables for theming.
+
+## Feature Comparison
+
+| Feature | Infinite Table (free) | MUI X Community (free) | MUI X Pro ($299/dev/yr) | MUI X Premium ($599/dev/yr) |
+|---|---|---|---|---|
+| Sorting (single + multi) | Yes | Yes (single) | Yes (multi) | Yes (multi) |
+| Column filtering | Yes | Yes (single) | Yes (multi) | Yes (multi) |
+| Column resizing | Yes | — | Yes | Yes |
+| Column reordering | Yes | — | Yes | Yes |
+| Column pinning | Yes | — | Yes | Yes |
+| Column grouping (headers) | Yes | Yes | Yes | Yes |
+| Row grouping | Yes | — | — | Yes |
+| Aggregations | Yes | — | — | Yes |
+| Pivoting | Yes | — | — | Yes |
+| Tree data | Yes | — | Yes | Yes |
+| Master-detail | Yes | — | Yes | Yes |
+| Row virtualization | Yes | Yes (≤100 rows) | Yes | Yes |
+| Column virtualization | Yes | — | Yes | Yes |
+| Cell editing | Yes | Yes | Yes | Yes |
+| Cell selection | Yes | — | — | Yes |
+| Row selection | Yes | Yes | Yes | Yes |
+| Keyboard navigation | Yes | Yes | Yes | Yes |
+| Lazy loading | Yes | — | Yes (server-side) | Yes |
+| Live pagination | Yes | — | — | — |
+| Context menus | Yes | — | — | — |
+| Excel export | — | — | — | Yes |
+| Clipboard (copy/paste) | — | — | — | Yes |
+| Pagination > 100 rows/page | — | — | Yes | Yes |
+
+<Note>
+
+MUI X uses a tiered model: row grouping, pivoting, aggregations, and cell selection require the Premium plan ($599/dev/year). Column resizing, pinning, reordering, tree data, and master-detail require at least Pro ($299/dev/year). Feature details are from the [MUI pricing page](https://mui.com/pricing/).
+
+Infinite Table includes all of these features in the free Community build (a "Powered by Infinite Table" footer is displayed). A paid license ($395/dev/year) removes the footer.
+
+</Note>
+
+## Pricing
+
+| | Infinite Table | MUI X Pro | MUI X Premium | MUI X Enterprise |
+|---|---|---|---|---|
+| **Price** | [$395/dev/year](https://infinite-table.com/pricing) | [$299/dev/year](https://mui.com/pricing/) | [$599/dev/year](https://mui.com/pricing/) | [$1,399/dev/year](https://mui.com/pricing/) |
+| **Grouping + pivoting** | Included (free) | — | Included | Included |
+| **Tree data + master-detail** | Included (free) | Included | Included | Included |
+| **Column resizing + pinning** | Included (free) | Included | Included | Included |
+| **Deployment license** | None | None | None | None |
+| **Support** | Email (paid) | Community | Priority over Community | Priority over Pro |
+
+To match Infinite Table's feature set (grouping, pivoting, aggregations, cell selection), you need MUI X Premium at $599/dev/year. Infinite Table offers these for free — or at $395/dev/year if you want to remove the footer.
+
+For a team of five developers needing pivoting:
+- Infinite Table: $1,775/year (or $0 with footer)
+- MUI X Premium: $2,995/year
+
+## When MUI X Data Grid is the better choice
+
+- **You're already in the MUI ecosystem.** If your app uses Material UI, MUI X Data Grid inherits your MUI theme, spacing, palette, and typography with zero configuration. Infinite Table uses its own CSS variables and won't automatically pick up your MUI theme tokens.
+- **You need the full MUI X suite.** MUI X includes date pickers, charts, tree view, and a scheduler under a single license. If you need multiple MUI X components, a Pro or Premium license covers them all — better value than paying separately for each tool.
+- **You value Material Design consistency.** The Data Grid follows Material Design patterns by default. If your design spec is Material Design, MUI X Data Grid is a natural fit.
+- **Community size.** MUI has a very large user community — Material UI's npm downloads are in the millions per week. More community resources, more Stack Overflow answers, more third-party tutorials.
+- **Column-level features at the Pro tier.** If you need column resizing, pinning, reordering, and tree data but not grouping/pivoting, MUI X Pro at $299/dev/year covers those features. Infinite Table offers the same features free (with footer) or at $395/dev/year (without), so MUI X Pro is comparable in price while covering non-grid MUI X components too.
+
+## When Infinite Table is the better fit
+
+- **You need grouping, pivoting, and aggregations without paying for Premium.** These are free in Infinite Table's Community build. MUI X requires the Premium plan ($599/dev/year) for the same features.
+- **You're not using Material UI.** If your app uses Tailwind, vanilla CSS, or another design system, MUI X Data Grid brings along the MUI styling system as a dependency. Infinite Table uses plain CSS variables and works with any styling approach.
+- **Column virtualization on the free tier.** Infinite Table virtualizes both rows and columns by default. MUI X Community only virtualizes rows up to 100 rows; column virtualization and unlimited row virtualization require Pro.
+- **Live pagination and context menus.** Infinite Table includes built-in live pagination and context menus. MUI X does not offer equivalents at any tier.
+- **Simpler licensing model.** Infinite Table has one plan. MUI X has four tiers where features are spread across Community, Pro, Premium, and Enterprise — you need to check which tier covers each feature you need.
+
+## Get started
+
+<TerminalBlock>
+npm i @infinite-table/infinite-react
+</TerminalBlock>
+
+- [Getting Started guide](/docs/learn/getting-started)
+- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
+- [Theming with CSS variables](/docs/learn/theming/css-variables)
+- [Pricing](/pricing)
+- [MUI X Data Grid official docs](https://mui.com/x/react-data-grid/)

--- a/www/content/docs/learn/compare/tanstack-table.page.md
+++ b/www/content/docs/learn/compare/tanstack-table.page.md
@@ -1,26 +1,71 @@
 ---
 title: Infinite Table vs TanStack Table
-description: A detailed comparison of Infinite Table and TanStack Table. Rendered component vs headless library — architecture, features, and when TanStack Table is the better choice.
+description: A detailed comparison of Infinite Table and TanStack Table. Declarative rendered grid vs headless logic library — architecture, features, and when TanStack Table is the better choice.
 ---
 
-[TanStack Table](https://tanstack.com/table) (formerly React Table) is a popular, MIT-licensed headless table library. It provides table logic — sorting, filtering, grouping, pagination — but no UI. You build the rendering layer yourself.
+[TanStack Table](https://tanstack.com/table) (formerly React Table) is a popular, MIT-licensed headless table library. It provides table logic — sorting, filtering, grouping, pagination — but no UI. You bring your own JSX, your own styles, your own virtualization, your own keyboard navigation.
 
-Infinite Table is a fully rendered React data grid component. You pass data and column definitions; it renders a virtualized, styled grid.
+Infinite Table is a fully rendered React data grid. You pass props — columns, data, grouping configuration — and get a complete, virtualized, keyboard-navigable grid with theming out of the box. Both are valid approaches. The question is where you want to spend your engineering time.
 
-These are fundamentally different tools solving overlapping problems. This page helps you decide which approach fits your project.
+## Two ends of a spectrum
+
+The "Why Another DataGrid?" question comes down to a positioning choice. At one end of the spectrum is AG Grid — a full-featured grid engine that wraps itself for React. At the other end is TanStack Table — headless hooks that give you total rendering control but require you to build everything visible.
+
+Infinite Table sits in the middle: **a declarative React component that ships the grid**. You get the React-native API feel (props, controlled state, JSX cell renderers) without having to construct the table markup, virtualization, focus management, and accessibility yourself.
+
+```tsx
+// TanStack Table: you provide all the JSX
+const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+return (
+  <table>
+    <thead>
+      {table.getHeaderGroups().map(headerGroup => (
+        <tr key={headerGroup.id}>
+          {headerGroup.headers.map(header => (
+            <th key={header.id}>
+              {flexRender(header.column.columnDef.header, header.getContext())}
+            </th>
+          ))}
+        </tr>
+      ))}
+    </thead>
+    <tbody>
+      {table.getRowModel().rows.map(row => (
+        <tr key={row.id}>
+          {row.getVisibleCells().map(cell => (
+            <td key={cell.id}>
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+```
+
+```tsx
+// Infinite Table: declarative props, grid ships complete
+<DataSource<T> primaryKey="id" data={dataSource}>
+  <InfiniteTable<T> columns={columns} />
+</DataSource>
+```
+
+Both examples display tabular data. The first gives you total control over every `<tr>` and `<td>`. The second gives you a working grid — virtualized, keyboard-navigable, themeable — in two components.
 
 ## Architecture
 
 | | Infinite Table | TanStack Table |
 |---|---|---|
-| **Type** | Rendered component | Headless logic library |
-| **Frameworks** | React | React, Vue, Solid, Svelte, vanilla JS |
+| **Type** | Rendered React component | Headless logic library |
 | **What you get** | Full UI: virtualized grid, headers, cells, scrollbars, keyboard nav, theming | Table state + utilities; you provide all DOM and styling |
+| **API style** | Declarative props (controlled + uncontrolled) | Hooks that return row/cell models; you render everything |
+| **Cell rendering** | JSX — pass a React component as a column prop | You call `flexRender()` yourself inside your own markup |
+| **Frameworks** | React | React, Vue, Solid, Svelte, vanilla JS |
 | **Virtualization** | Built-in row + column virtualization | Not included; pair with [TanStack Virtual](https://tanstack.com/virtual) or your own |
 | **TypeScript** | First-class | First-class |
 | **Bundle** | Single package, includes CSS | Tiny core; total size depends on what you build on top |
-
-The core trade-off is **control vs. convenience**. TanStack Table gives you total control over rendering. Infinite Table gives you a working data grid out of the box.
 
 ## Feature Comparison
 
@@ -44,8 +89,6 @@ The core trade-off is **control vs. convenience**. TanStack Table gives you tota
 | Lazy loading / live pagination | Built-in | Not included (pagination logic available) |
 | Row + column virtualization | Built-in | Not included; use TanStack Virtual |
 | Theming | CSS variables, multiple built-in themes | N/A — you style everything |
-| License | Free with footer; paid removes footer | MIT (free) |
-| Price | [$395/dev/year](https://infinite-table.com/pricing) | Free |
 
 <Note>
 
@@ -63,46 +106,30 @@ With TanStack Table, building a production data grid involves:
 4. Handling keyboard navigation and ARIA attributes for accessibility.
 5. Styling everything from scratch or integrating with your design system.
 
-This is the right approach when you need pixel-perfect control or are building a design-system component library. But it means weeks of work to reach feature parity with a rendered grid.
+This is the right approach when you need pixel-perfect control or are building a design-system component library. But it means weeks of work to reach feature parity with a rendered grid — and that code becomes yours to maintain.
 
-With Infinite Table, you write:
-
-```tsx
-import {
-  InfiniteTable,
-  DataSource,
-} from '@infinite-table/infinite-react';
-import '@infinite-table/infinite-react/index.css';
-
-<DataSource<YourType> primaryKey="id" data={dataSource}>
-  <InfiniteTable<YourType> columns={columns} />
-</DataSource>
-```
-
-Grouping, pivoting, filtering, virtualization, keyboard navigation, and theming work immediately.
+With Infinite Table, grouping, pivoting, filtering, virtualization, keyboard navigation, and theming work the moment you render the component. You customise through props and JSX cell renderers, not by rebuilding the grid's internals.
 
 ## Pricing
 
 TanStack Table is MIT-licensed and free. There is no paid tier.
 
-Infinite Table's Community build is also free (all features included) but displays a "Powered by Infinite Table" footer. A paid license ($395/dev/year) removes the footer and adds email support.
-
-If your project has zero budget for a grid license and you're prepared to invest development time building UI, TanStack Table is the obvious choice. If you value shipping faster and want a complete, ready-to-use grid, Infinite Table's free tier gives you everything with only a small footer.
+Infinite Table's Community build is also free — all features included — but displays a "Powered by Infinite Table" footer. A [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes the footer and adds email support.
 
 ## When TanStack Table is the better choice
 
-- **Total rendering control.** You need pixel-perfect custom UI, or you're building a table component for a design-system library where the rendered output must match your system exactly.
+- **Total rendering control.** You need pixel-perfect custom UI, or you're building a table component for a design-system library where the rendered output must match your design spec exactly.
 - **Multi-framework.** TanStack Table works across React, Vue, Solid, and Svelte. Infinite Table is React-only.
 - **Minimal bundle.** If you only need sorting and basic filtering on a small dataset (no virtualization, no grouping), TanStack Table's core is smaller than any full grid component.
-- **Zero cost, zero restrictions.** MIT with no footer, no license key, no terms beyond the MIT license.
-- **Existing investment.** If you already have a mature TanStack Table implementation, migrating to a rendered grid may not be worth it.
+- **Zero restrictions.** MIT license with no footer, no license key, no terms beyond MIT.
+- **Existing investment.** If your team has already built a mature grid UI on top of TanStack Table, migrating to a rendered grid may not justify the effort.
 
 ## When Infinite Table is the better fit
 
-- **You need a working grid now.** Infinite Table ships with a complete UI — virtualization, grouping, pivoting, filtering, keyboard navigation, theming — out of the box. No weeks of custom rendering work.
-- **Complex data features.** Master-detail, tree grids, lazy loading, live pagination, cell editing, and cell selection are built in. Building these on top of TanStack Table is a significant engineering project.
+- **You want to ship the grid, not build it.** Infinite Table delivers a production-ready grid — virtualized, keyboard-navigable, themed — out of the box. You focus on your product, not on re-implementing table infrastructure.
+- **You want React-native API feel without the assembly work.** TanStack Table gives you hooks and row models; you assemble the JSX. Infinite Table gives you declarative props and controlled state — the same patterns you use in every other React component — but ships the complete UI so you don't have to build it yourself.
+- **Complex data features built in.** Master-detail, tree grids, lazy loading, live pagination, cell editing, cell selection, and context menus are all included. Building these on top of TanStack Table is a significant engineering project.
 - **Accessibility and keyboard support.** Infinite Table includes keyboard navigation and focus management. With TanStack Table, you implement these yourself.
-- **You want to focus on your product, not your grid.** If the data grid is infrastructure rather than a core differentiator, a rendered component saves time.
 
 ## Get started
 

--- a/www/content/docs/learn/compare/tanstack-table.page.md
+++ b/www/content/docs/learn/compare/tanstack-table.page.md
@@ -1,0 +1,116 @@
+---
+title: Infinite Table vs TanStack Table
+description: A detailed comparison of Infinite Table and TanStack Table. Rendered component vs headless library — architecture, features, and when TanStack Table is the better choice.
+---
+
+[TanStack Table](https://tanstack.com/table) (formerly React Table) is a popular, MIT-licensed headless table library. It provides table logic — sorting, filtering, grouping, pagination — but no UI. You build the rendering layer yourself.
+
+Infinite Table is a fully rendered React data grid component. You pass data and column definitions; it renders a virtualized, styled grid.
+
+These are fundamentally different tools solving overlapping problems. This page helps you decide which approach fits your project.
+
+## Architecture
+
+| | Infinite Table | TanStack Table |
+|---|---|---|
+| **Type** | Rendered component | Headless logic library |
+| **Frameworks** | React | React, Vue, Solid, Svelte, vanilla JS |
+| **What you get** | Full UI: virtualized grid, headers, cells, scrollbars, keyboard nav, theming | Table state + utilities; you provide all DOM and styling |
+| **Virtualization** | Built-in row + column virtualization | Not included; pair with [TanStack Virtual](https://tanstack.com/virtual) or your own |
+| **TypeScript** | First-class | First-class |
+| **Bundle** | Single package, includes CSS | Tiny core; total size depends on what you build on top |
+
+The core trade-off is **control vs. convenience**. TanStack Table gives you total control over rendering. Infinite Table gives you a working data grid out of the box.
+
+## Feature Comparison
+
+| Feature | Infinite Table | TanStack Table |
+|---|---|---|
+| Sorting | Built-in UI + logic | Logic only |
+| Column filtering | Built-in filter UI + logic | Logic only |
+| Row grouping | Built-in, with expand/collapse UI | Logic only |
+| Aggregations | Built-in | Logic only |
+| Pivoting | Built-in | Logic only |
+| Tree data | Built-in (TreeGrid) | Logic only (expanding rows) |
+| Column resizing | Built-in | Logic helpers; you build the drag handles |
+| Column reordering | Built-in | Not included |
+| Column pinning | Built-in | Logic helpers; you implement sticky positioning |
+| Cell editing | Built-in | Not included |
+| Cell selection | Built-in | Not included |
+| Row selection | Built-in UI (checkbox, click) | Logic only |
+| Keyboard navigation | Built-in | Not included |
+| Context menus | Built-in | Not included |
+| Master-detail | Built-in | Not included |
+| Lazy loading / live pagination | Built-in | Not included (pagination logic available) |
+| Row + column virtualization | Built-in | Not included; use TanStack Virtual |
+| Theming | CSS variables, multiple built-in themes | N/A — you style everything |
+| License | Free with footer; paid removes footer | MIT (free) |
+| Price | [$395/dev/year](https://infinite-table.com/pricing) | Free |
+
+<Note>
+
+"Logic only" means TanStack Table handles the state and computations, but you write all the JSX, CSS, event handlers, and accessibility attributes. This is powerful but requires substantial development effort for a production-grade data grid.
+
+</Note>
+
+## What "headless" means in practice
+
+With TanStack Table, building a production data grid involves:
+
+1. Rendering the `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<td>` (or `<div>`-based layout) yourself.
+2. Wiring up virtualization (typically TanStack Virtual) for large datasets.
+3. Building filter UIs, sort indicators, group expand/collapse toggles, resize handles, and column reorder drag-and-drop.
+4. Handling keyboard navigation and ARIA attributes for accessibility.
+5. Styling everything from scratch or integrating with your design system.
+
+This is the right approach when you need pixel-perfect control or are building a design-system component library. But it means weeks of work to reach feature parity with a rendered grid.
+
+With Infinite Table, you write:
+
+```tsx
+import {
+  InfiniteTable,
+  DataSource,
+} from '@infinite-table/infinite-react';
+import '@infinite-table/infinite-react/index.css';
+
+<DataSource<YourType> primaryKey="id" data={dataSource}>
+  <InfiniteTable<YourType> columns={columns} />
+</DataSource>
+```
+
+Grouping, pivoting, filtering, virtualization, keyboard navigation, and theming work immediately.
+
+## Pricing
+
+TanStack Table is MIT-licensed and free. There is no paid tier.
+
+Infinite Table's Community build is also free (all features included) but displays a "Powered by Infinite Table" footer. A paid license ($395/dev/year) removes the footer and adds email support.
+
+If your project has zero budget for a grid license and you're prepared to invest development time building UI, TanStack Table is the obvious choice. If you value shipping faster and want a complete, ready-to-use grid, Infinite Table's free tier gives you everything with only a small footer.
+
+## When TanStack Table is the better choice
+
+- **Total rendering control.** You need pixel-perfect custom UI, or you're building a table component for a design-system library where the rendered output must match your system exactly.
+- **Multi-framework.** TanStack Table works across React, Vue, Solid, and Svelte. Infinite Table is React-only.
+- **Minimal bundle.** If you only need sorting and basic filtering on a small dataset (no virtualization, no grouping), TanStack Table's core is smaller than any full grid component.
+- **Zero cost, zero restrictions.** MIT with no footer, no license key, no terms beyond the MIT license.
+- **Existing investment.** If you already have a mature TanStack Table implementation, migrating to a rendered grid may not be worth it.
+
+## When Infinite Table is the better fit
+
+- **You need a working grid now.** Infinite Table ships with a complete UI — virtualization, grouping, pivoting, filtering, keyboard navigation, theming — out of the box. No weeks of custom rendering work.
+- **Complex data features.** Master-detail, tree grids, lazy loading, live pagination, cell editing, and cell selection are built in. Building these on top of TanStack Table is a significant engineering project.
+- **Accessibility and keyboard support.** Infinite Table includes keyboard navigation and focus management. With TanStack Table, you implement these yourself.
+- **You want to focus on your product, not your grid.** If the data grid is infrastructure rather than a core differentiator, a rendered component saves time.
+
+## Get started
+
+<TerminalBlock>
+npm i @infinite-table/infinite-react
+</TerminalBlock>
+
+- [Getting Started guide](/docs/learn/getting-started)
+- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
+- [Pricing](/pricing)
+- [TanStack Table official docs](https://tanstack.com/table/latest/docs/introduction)

--- a/www/content/docs/learn/compare/tanstack-table.page.md
+++ b/www/content/docs/learn/compare/tanstack-table.page.md
@@ -71,24 +71,24 @@ Both examples display tabular data. The first gives you total control over every
 
 | Feature | Infinite Table | TanStack Table |
 |---|---|---|
-| Sorting | Built-in UI + logic | Logic only |
-| Column filtering | Built-in filter UI + logic | Logic only |
-| Row grouping | Built-in, with expand/collapse UI | Logic only |
-| Aggregations | Built-in | Logic only |
-| Pivoting | Built-in | Logic only |
-| Tree data | Built-in (TreeGrid) | Logic only (expanding rows) |
-| Column resizing | Built-in | Logic helpers; you build the drag handles |
-| Column reordering | Built-in | Not included |
-| Column pinning | Built-in | Logic helpers; you implement sticky positioning |
-| Cell editing | Built-in | Not included |
-| Cell selection | Built-in | Not included |
-| Row selection | Built-in UI (checkbox, click) | Logic only |
-| Keyboard navigation | Built-in | Not included |
-| Context menus | Built-in | Not included |
-| Master-detail | Built-in | Not included |
-| Lazy loading / live pagination | Built-in | Not included (pagination logic available) |
-| Row + column virtualization | Built-in | Not included; use TanStack Virtual |
-| Theming | CSS variables, multiple built-in themes | N/A — you style everything |
+| Sorting | ✅ | 🔴 (logic only) |
+| Column filtering | ✅ | 🔴 (logic only) |
+| Row grouping | ✅ | 🔴 (logic only) |
+| Aggregations | ✅ | 🔴 (logic only) |
+| Pivoting | ✅ | 🔴 (logic only) |
+| Tree data | ✅ | 🔴 (logic only) |
+| Column resizing | ✅ | 🔴 (logic helpers) |
+| Column reordering | ✅ | 🔴 |
+| Column pinning | ✅ | 🔴 (logic helpers) |
+| Cell editing | ✅ | 🔴 |
+| Cell selection | ✅ | 🔴 |
+| Row selection | ✅ | 🔴 (logic only) |
+| Keyboard navigation | ✅ | 🔴 |
+| Context menus | ✅ | 🔴 |
+| Master-detail | ✅ | 🔴 |
+| Lazy loading / live pagination | ✅ | 🔴 (pagination logic available) |
+| Row + column virtualization | ✅ | 🔴 (use TanStack Virtual) |
+| Theming | ✅ | 🔴 |
 
 <Note>
 
@@ -114,7 +114,7 @@ With Infinite Table, grouping, pivoting, filtering, virtualization, keyboard nav
 
 TanStack Table is MIT-licensed and free. There is no paid tier.
 
-Infinite Table's Community build is also free — all features included — but displays a "Powered by Infinite Table" footer. A [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes the footer and adds email support.
+Infinite Table is also free — all features included — but displays a "Powered by Infinite Table" footer. A [paid license ($395/dev/year)](https://infinite-table.com/pricing) removes the footer and adds email support.
 
 ## When TanStack Table is the better choice
 
@@ -127,17 +127,33 @@ Infinite Table's Community build is also free — all features included — but 
 ## When Infinite Table is the better fit
 
 - **You want to ship the grid, not build it.** Infinite Table delivers a production-ready grid — virtualized, keyboard-navigable, themed — out of the box. You focus on your product, not on re-implementing table infrastructure.
-- **You want React-native API feel without the assembly work.** TanStack Table gives you hooks and row models; you assemble the JSX. Infinite Table gives you declarative props and controlled state — the same patterns you use in every other React component — but ships the complete UI so you don't have to build it yourself.
+- **You want native React API feel without the assembly work.** TanStack Table gives you hooks and row models; you assemble the JSX. Infinite Table gives you declarative props and controlled state — the same patterns you use in every other React component — but ships the complete UI so you don't have to build it yourself. Of course you still have a lot of control over column cells, headers, filters, etc.
 - **Complex data features built in.** Master-detail, tree grids, lazy loading, live pagination, cell editing, cell selection, and context menus are all included. Building these on top of TanStack Table is a significant engineering project.
 - **Accessibility and keyboard support.** Infinite Table includes keyboard navigation and focus management. With TanStack Table, you implement these yourself.
 
-## Get started
 
-<TerminalBlock>
-npm i @infinite-table/infinite-react
-</TerminalBlock>
+<HeroCards>
+<YouWillLearnCard title="Getting Started" path="/docs/learn/getting-started">
+Install the package, render your first DataGrid, and learn how `<DataSource />` and `<InfiniteTable />` work together.
+</YouWillLearnCard>
+<YouWillLearnCard title="Grouping and pivoting" path="/docs/learn/grouping-and-pivoting">
+Built-in grouping, aggregations, and pivoting — without writing the UI layer yourself.
+</YouWillLearnCard>
+</HeroCards>
 
-- [Getting Started guide](/docs/learn/getting-started)
-- [Grouping and Pivoting](/docs/learn/grouping-and-pivoting)
-- [Pricing](/pricing)
-- [TanStack Table official docs](https://tanstack.com/table/latest/docs/introduction)
+<HeroCards>
+<YouWillLearnCard title="Pricing" path="/pricing">
+Use Infinite Table free with a footer, or buy a license to remove it and get email support.
+</YouWillLearnCard>
+<YouWillLearnCard title="TanStack Table docs" path="https://tanstack.com/table/latest/docs/introduction" newTab>
+Read TanStack Table's official introduction.
+</YouWillLearnCard>
+</HeroCards>
+
+## Help us keep this comparison up-to-date
+
+This page is our reading of TanStack Table's public docs as of mid-2026. We want it to stay accurate. If you work on TanStack Table — or you've spotted something that's wrong, outdated, or missing context — please tell us. We will update the page.
+
+- [Edit this page on GitHub](https://github.com/infinite-table/infinite-react/edit/master/www/content/docs/learn/compare/tanstack-table.page.md) and open a pull request
+- [File a correction issue](https://github.com/infinite-table/infinite-react/issues/new?template=compare_page_correction.md&title=Compare%20page%20correction%3A%20TanStack%20Table)
+- Email [admin@infinite-table.com](mailto:admin@infinite-table.com?subject=Compare%20page%20correction%3A%20TanStack%20Table) with the URL and what should change

--- a/www/next-env.d.ts
+++ b/www/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -48,6 +48,7 @@
         "react-dom": "^19.2.0",
         "react-live": "^2.2.3",
         "react-select": "^5.4.0",
+        "remark-gfm": "^4.0.1",
         "remark-mdx-code-meta": "^2.0.0",
         "scroll-into-view-if-needed": "^2.2.25",
         "serverless-http": "^2.7.0",
@@ -14197,6 +14198,48 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -14228,6 +14271,117 @@
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14686,6 +14840,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -19597,6 +19872,39 @@
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
         "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/www/package.json
+++ b/www/package.json
@@ -79,6 +79,7 @@
     "react-dom": "^19.2.0",
     "react-live": "^2.2.3",
     "react-select": "^5.4.0",
+    "remark-gfm": "^4.0.1",
     "remark-mdx-code-meta": "^2.0.0",
     "scroll-into-view-if-needed": "^2.2.25",
     "serverless-http": "^2.7.0",

--- a/www/src/components/renderMarkdownPage.tsx
+++ b/www/src/components/renderMarkdownPage.tsx
@@ -1,6 +1,7 @@
 import { compile, run } from '@mdx-js/mdx';
 import * as runtime from 'react/jsx-runtime';
 import remarkMdx from 'remark-mdx';
+import remarkGfm from 'remark-gfm';
 
 import { useMDXComponents } from '../../content/new-mdx-components';
 import { siteContent } from '@www/content';
@@ -54,6 +55,7 @@ export async function renderMarkdownPage(options: {
       outputFormat: 'function-body',
 
       remarkPlugins: [
+        remarkGfm,
         remarkMdx,
         markdownLinkChecker({
           fileInfo,

--- a/www/src/sidebarLearn.json
+++ b/www/src/sidebarLearn.json
@@ -343,5 +343,23 @@
         "path": "/docs/learn/examples/dynamic-pivoting-example"
       }
     ]
+  },
+  {
+    "title": "Compare",
+    "path": "/docs/learn/compare",
+    "routes": [
+      {
+        "title": "vs AG Grid",
+        "path": "/docs/learn/compare/ag-grid"
+      },
+      {
+        "title": "vs TanStack Table",
+        "path": "/docs/learn/compare/tanstack-table"
+      },
+      {
+        "title": "vs MUI X Data Grid",
+        "path": "/docs/learn/compare/mui-x-data-grid"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds official comparison pages to the Infinite Table website. Leads with what Infinite Table is good at (React-native feel, small composable API, grouping/pivoting included) without negative marketing toward competitors.

## New URLs

- `/docs/learn/compare` — Hub with quick comparison table
- `/docs/learn/compare/ag-grid` — vs AG Grid
- `/docs/learn/compare/tanstack-table` — vs TanStack Table
- `/docs/learn/compare/mui-x-data-grid` — vs MUI X Data Grid

## Framing

Each page leads with Infinite Table's strengths, not competitors' weaknesses:

**AG Grid** — Three arguments in order:
1. React-native feel vs multi-framework architecture (code examples, neutral framing — "Neither approach is wrong")
2. Small composable API vs comprehensive configuration surface (verified examples from AG Grid docs, framed as breadth-vs-composability trade-off)
3. Grouping/pivoting in the free tier

**TanStack Table** — Infinite Table as "the declarative middle" between full rendered grids and headless logic. Side-by-side code examples.

**MUI X** — Design-system coupling (MUI theme vs CSS variables) and DataSource/InfiniteTable separation. Acknowledges MUI X's tiering gives flexibility.

**Tone** — No negative marketing. AG Grid's large API is presented as breadth that serves enterprise teams. TanStack's headless approach is presented as the right choice for teams that need rendering control. MUI X's ecosystem is presented as valuable for MUI users. "When [competitor] wins" sections are generous (AG Grid's has 5 bullets).

Price stays as factual data, never the headline or main pitch.

## Infrastructure

Added `remark-gfm` to the MDX pipeline for proper HTML table rendering.

## Screenshots

[Hub page](https://cursor.com/agents/bc-a9361e8d-d660-4b6e-b825-9994735cce71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frevised_compare_hub_first_screen.png)
[AG Grid page](https://cursor.com/agents/bc-a9361e8d-d660-4b6e-b825-9994735cce71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fag_grid_api_surface_section.png)

## Demo

[revised_comparison_pages_walkthrough.mp4](https://cursor.com/agents/bc-a9361e8d-d660-4b6e-b825-9994735cce71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frevised_comparison_pages_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9361e8d-d660-4b6e-b825-9994735cce71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9361e8d-d660-4b6e-b825-9994735cce71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

