### PR TITLE
Bring respectful comparison copy onto master (cherry-pick from stale branch)

### DIFF
--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -40,6 +40,26 @@ const onButtonClick = () => {
 
 No ref, no imperative API — just React state. The same pattern you use for `<input value={...} onChange={...} />` works for the entire grid.
 
+## A small, composable API vs a large configuration surface
+
+AG Grid has been shipping features for over a decade across four frameworks. The result is an enormous API surface — the [`GridOptions` interface](https://www.ag-grid.com/react-data-grid/grid-options/) spans hundreds of props across 25+ categories. That surface carries the weight of its history: overlapping options, boolean flags that only apply when another flag is set, and legacy alternatives that coexist with their replacements.
+
+A few real patterns from the AG Grid docs:
+
+- **Overlays** have three generations of API living side by side. The current `overlayComponent` / `overlayComponentSelector` approach coexists with the older `loadingOverlayComponent`, `noRowsOverlayComponent`, `overlayLoadingTemplate`, and `overlayNoRowsTemplate` — all still accepted. The docs annotate the older props with "Prefer `overlayComponent`/`overlayComponentSelector`", but both paths work. Similarly, `suppressNoRowsOverlay` is a standalone boolean while `suppressOverlays` takes an array of overlay names — two ways to suppress the same thing.
+- **Row grouping** alone accounts for roughly 20 grid-level props: `groupDisplayType`, `autoGroupColumnDef`, `groupRowRenderer`, `showOpenedGroup`, `groupHideOpenParents`, `groupHideColumnsUntilExpanded`, `groupHideParentOfSingleChild`, `groupAllowUnbalanced`, `groupMaintainOrder`, `groupDefaultExpanded`, `isGroupOpenByDefault`, `groupLockGroupColumns`, `suppressGroupRowsSticky`, `rowGroupPanelShow`, `suppressDragLeaveHidesColumns`, `suppressGroupChangesColumnVisibility`, `functionsReadOnly`, and more — each a separate configuration knob.
+- **Column menus** offer `columnMenu` (with values `'legacy'` and `'new'`), `getMainMenuItems`, and `getColumnMenuItems` — where the docs note that `getColumnMenuItems` "takes precedence over `getMainMenuItems` for the column menu." The prop `suppressMenuHide` is only recommended when `columnMenu = 'legacy'`.
+
+None of this is a criticism of AG Grid's engineering — supporting four frameworks and a decade of backwards compatibility requires exactly this kind of surface. But it's a trade-off. Every `suppress*` boolean, every pair of overlapping callbacks, every legacy-vs-new toggle is something your team has to understand, or at least know not to touch.
+
+Infinite Table makes the opposite bet: keep the API surface small and composable.
+
+- Instead of a forest of boolean flags, Infinite Table uses **function props as building blocks**. The [`groupColumn`](/docs/learn/grouping-and-pivoting/grouping-rows) prop can be a column object (single group column) or a function (called for each generated column). One prop, two behaviours — no `groupDisplayType` + `autoGroupColumnDef` + `groupRowRenderer` to coordinate.
+- Instead of `suppress*` booleans, features are **controlled or uncontrolled**. Want to manage sorting yourself? Pass `sortInfo` (controlled). Want the grid to handle it? Pass `defaultSortInfo` (uncontrolled). The same pattern as `value` vs `defaultValue` on a React `<input>`.
+- Instead of `getMainMenuItems` + `getColumnMenuItems` with precedence rules, Infinite Table has a single [`getContextMenuItems`](/docs/learn/context-menus/using-context-menus) callback.
+
+The result is a smaller surface you can hold in your head. Fewer props, fewer interactions between props, fewer "this only works when that other prop is set" footnotes.
+
 ## Architecture
 
 | | Infinite Table | AG Grid |
@@ -108,8 +128,8 @@ AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, t
 ## When Infinite Table is the better fit
 
 - **You want the grid to feel like React.** Infinite Table's API is props, controlled state, and JSX — the same patterns you use in every other React component. No grid-options objects, no imperative API calls, no syncing grid state back to React. If your team thinks in React, Infinite Table fits that mental model.
+- **You want a small, composable API you can reason about.** Infinite Table ships grouping, pivoting, and aggregations with a fraction of the configuration surface. Function props instead of boolean flag forests, controlled/uncontrolled patterns instead of `suppress*` toggles, one callback where AG Grid has two with precedence rules. Fewer props, fewer interactions between props, fewer surprises.
 - **You need grouping, pivoting, and aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid gates them behind the Enterprise tier.
-- **You want a composable, smaller API surface.** Infinite Table favours function props over boolean flags, and controlled/uncontrolled variants over imperative setters. The API is designed to compose — fewer props that do more, rather than hundreds of configuration options.
 - **Simpler licensing.** One plan, one key for the whole team, no deployment license.
 
 

--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -1,32 +1,36 @@
 ---
 title: Infinite Table vs AG Grid
-description: A detailed comparison of Infinite Table and AG Grid for React. React-native API vs framework-agnostic wrapper, features, and when AG Grid is the better choice.
+description: A detailed comparison of Infinite Table and AG Grid for React. Two different approaches to building data grids — and when each one is the right choice.
 ---
 
-[AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, used across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community. We respect what the AG Grid team has built — it's a feat of engineering.
+[AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, used across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community. The AG Grid team has been shipping for over a decade and the result is an impressively comprehensive product.
 
-The core difference is not price. It's how each grid relates to React.
+Infinite Table and AG Grid make different bets. This page walks through those differences honestly, including where AG Grid is the stronger choice.
 
-AG Grid was designed as a framework-agnostic rendering engine. Its React package is a wrapper — an adapter layer that translates between AG Grid's internal model and React components. The grid's state, lifecycle, and rendering happen outside React's reconciler. You configure it through a `gridOptions` object and interact with it through imperative API calls like `api.setColumnDefs()`, `api.refreshCells()`, and `api.getSelectedRows()`.
+## Two different approaches to React
 
-Infinite Table was built for React from the start. There is no wrapper layer. Columns, sorting, grouping, and filtering are React props — controlled or uncontrolled, like any React component. Cell renderers are plain JSX. The grid participates in React's component tree, re-rendering when props change.
+AG Grid supports four frameworks from a single codebase. That multi-framework architecture is a genuine strength — it means your organisation can standardise on one grid across Angular, Vue, and React projects. The trade-off is that AG Grid's core is framework-agnostic: state and rendering live inside the grid engine, with a React adapter layer on top. Configuration goes through a `gridOptions` object, and many operations use imperative API calls like `api.setColumnDefs()` or `api.refreshCells()`.
 
-## What this means in practice
+Infinite Table is React-only, and that choice shapes the API. Columns, sorting, grouping, and filtering are React props — controlled or uncontrolled, like any React form component. Cell renderers are plain JSX. The grid participates in React's component tree, re-rendering when props change.
 
-With AG Grid, you might write:
+Neither approach is wrong. They reflect different design priorities: AG Grid optimises for framework reach and breadth; Infinite Table optimises for feeling native to React.
+
+## What this looks like in code
+
+With AG Grid, updating columns typically goes through the API:
 
 ```tsx
-// AG Grid: imperative API to update columns
+// AG Grid: update columns via the imperative API
 const onButtonClick = () => {
   gridRef.current.api.setColumnDefs(newColumnDefs);
   gridRef.current.api.refreshCells({ force: true });
 };
 ```
 
-With Infinite Table, the same operation is a prop change:
+With Infinite Table, the same operation is a state change:
 
 ```tsx
-// Infinite Table: declarative React props
+// Infinite Table: update columns via React state
 const [columns, setColumns] = useState(initialColumns);
 
 const onButtonClick = () => {
@@ -38,36 +42,30 @@ const onButtonClick = () => {
 </DataSource>
 ```
 
-No ref, no imperative API — just React state. The same pattern you use for `<input value={...} onChange={...} />` works for the entire grid.
+The same `value` / `onChange` pattern you use for a React `<input>` works for the entire grid.
 
-## A small, composable API vs a large configuration surface
+## API surface: breadth vs composability
 
-AG Grid has been shipping features for over a decade across four frameworks. The result is an enormous API surface — the [`GridOptions` interface](https://www.ag-grid.com/react-data-grid/grid-options/) spans hundreds of props across 25+ categories. That surface carries the weight of its history: overlapping options, boolean flags that only apply when another flag is set, and legacy alternatives that coexist with their replacements.
+AG Grid covers a huge number of enterprise use cases, and its API reflects that breadth. The [`GridOptions` interface](https://www.ag-grid.com/react-data-grid/grid-options/) spans hundreds of props across 25+ categories — from row grouping and pivoting to charting, clipboard, and server-side row models. For teams that need that coverage, it's all there.
 
-A few real patterns from the AG Grid docs:
+That breadth naturally comes with complexity. Over a decade of multi-framework development, the API has grown to include multiple ways to configure the same behaviour — for example, overlays can be customised through `overlayComponent`, or through the older `loadingOverlayComponent` and `noRowsOverlayComponent`, or through template strings, all of which still work. Row grouping alone involves roughly 20 grid-level props. These aren't flaws — they're the result of supporting many years of backwards compatibility across four frameworks, and teams that rely on those options are glad they exist.
 
-- **Overlays** have three generations of API living side by side. The current `overlayComponent` / `overlayComponentSelector` approach coexists with the older `loadingOverlayComponent`, `noRowsOverlayComponent`, `overlayLoadingTemplate`, and `overlayNoRowsTemplate` — all still accepted. The docs annotate the older props with "Prefer `overlayComponent`/`overlayComponentSelector`", but both paths work. Similarly, `suppressNoRowsOverlay` is a standalone boolean while `suppressOverlays` takes an array of overlay names — two ways to suppress the same thing.
-- **Row grouping** alone accounts for roughly 20 grid-level props: `groupDisplayType`, `autoGroupColumnDef`, `groupRowRenderer`, `showOpenedGroup`, `groupHideOpenParents`, `groupHideColumnsUntilExpanded`, `groupHideParentOfSingleChild`, `groupAllowUnbalanced`, `groupMaintainOrder`, `groupDefaultExpanded`, `isGroupOpenByDefault`, `groupLockGroupColumns`, `suppressGroupRowsSticky`, `rowGroupPanelShow`, `suppressDragLeaveHidesColumns`, `suppressGroupChangesColumnVisibility`, `functionsReadOnly`, and more — each a separate configuration knob.
-- **Column menus** offer `columnMenu` (with values `'legacy'` and `'new'`), `getMainMenuItems`, and `getColumnMenuItems` — where the docs note that `getColumnMenuItems` "takes precedence over `getMainMenuItems` for the column menu." The prop `suppressMenuHide` is only recommended when `columnMenu = 'legacy'`.
+Infinite Table makes a different trade-off: keep the API surface small and composable.
 
-None of this is a criticism of AG Grid's engineering — supporting four frameworks and a decade of backwards compatibility requires exactly this kind of surface. But it's a trade-off. Every `suppress*` boolean, every pair of overlapping callbacks, every legacy-vs-new toggle is something your team has to understand, or at least know not to touch.
+- **Function props as building blocks.** The [`groupColumn`](/docs/learn/grouping-and-pivoting/grouping-rows) prop can be a column object (single group column) or a function (called for each generated column). One prop, two behaviours, composed through the same mechanism.
+- **Controlled and uncontrolled variants.** Want to manage sorting yourself? Pass `sortInfo` (controlled). Want the grid to handle it? Pass `defaultSortInfo` (uncontrolled). The same pattern as `value` vs `defaultValue` on a React `<input>`.
+- **Fewer props to coordinate.** Infinite Table ships grouping, pivoting, and aggregations — but with a smaller configuration surface. The bet is that fewer, more composable props are easier to learn and reason about for React teams.
 
-Infinite Table makes the opposite bet: keep the API surface small and composable.
-
-- Instead of a forest of boolean flags, Infinite Table uses **function props as building blocks**. The [`groupColumn`](/docs/learn/grouping-and-pivoting/grouping-rows) prop can be a column object (single group column) or a function (called for each generated column). One prop, two behaviours — no `groupDisplayType` + `autoGroupColumnDef` + `groupRowRenderer` to coordinate.
-- Instead of `suppress*` booleans, features are **controlled or uncontrolled**. Want to manage sorting yourself? Pass `sortInfo` (controlled). Want the grid to handle it? Pass `defaultSortInfo` (uncontrolled). The same pattern as `value` vs `defaultValue` on a React `<input>`.
-- Instead of `getMainMenuItems` + `getColumnMenuItems` with precedence rules, Infinite Table has a single [`getContextMenuItems`](/docs/learn/context-menus/using-context-menus) callback.
-
-The result is a smaller surface you can hold in your head. Fewer props, fewer interactions between props, fewer "this only works when that other prop is set" footnotes.
+These are genuinely different philosophies. AG Grid's large surface means there's usually a dedicated prop for any specific requirement. Infinite Table's smaller surface means you compose general-purpose building blocks to get there.
 
 ## Architecture
 
 | | Infinite Table | AG Grid |
 |---|---|---|
-| **Built for** | React | Framework-agnostic (JS, Angular, Vue, React) |
-| **React integration** | Native — renders through React's reconciler | Wrapper — React adapter around internal DOM engine |
-| **API style** | Declarative props, controlled + uncontrolled | Grid-options object, imperative `api.*` calls |
-| **Cell renderers** | Plain JSX components | AG Grid component interface (React components supported via adapter) |
+| **Built for** | React | Multi-framework (JS, Angular, Vue, React) |
+| **React integration** | Native — renders through React's reconciler | Framework-agnostic core with React adapter |
+| **API style** | Declarative props, controlled + uncontrolled | Comprehensive configuration object, imperative API |
+| **Cell renderers** | Plain JSX components | AG Grid component interface (React components supported) |
 | **State management** | Lives in React (useState, context, external stores) | Lives inside the grid; synced to React via callbacks |
 | **TypeScript** | Written in TypeScript, first-class types | Written in TypeScript, first-class types |
 | **Virtualization** | Row + column | Row + column |
@@ -104,7 +102,7 @@ The result is a smaller surface you can hold in your head. Fewer props, fewer in
 
 <Note>
 
-AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, tree data, or master-detail. Those require AG Grid Enterprise. Infinite Table includes all of these in the free Community build (with a "Powered by Infinite Table" footer). A paid license key removes the footer.
+AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, tree data, or master-detail. Those require AG Grid Enterprise. Infinite Table includes all of these in the free build (with a "Powered by Infinite Table" footer). A paid license key removes the footer.
 
 </Note>
 
@@ -120,16 +118,17 @@ AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, t
 
 ## When AG Grid is the better choice
 
-- **Multi-framework projects.** If you need the same data grid across Angular, Vue, and React codebases, AG Grid is the only option here — Infinite Table is React-only. AG Grid's framework-agnostic core is a strength when your organisation standardises on one grid across teams.
-- **The widest feature surface.** AG Grid Enterprise includes built-in charting, clipboard, Excel export, column tool panels, status bars, and a full server-side row model with partial store. If you need several of these, AG Grid covers them in one package.
-- **Enormous community and ecosystem.** With over 1M weekly npm downloads and 13k+ GitHub stars, AG Grid has deep community resources, Stack Overflow coverage, and third-party integrations. If you value ecosystem maturity, AG Grid is unmatched.
-- **You prefer the imperative API.** If your team already knows AG Grid's `api.*` pattern from other projects, or you prefer imperative control over the grid's state, AG Grid's model may feel more natural to you than a prop-driven React API.
+- **Multi-framework projects.** If you need the same data grid across Angular, Vue, and React codebases, AG Grid is the clear choice — Infinite Table is React-only. Standardising on one grid across frameworks saves training time and keeps behaviour consistent.
+- **The widest feature surface.** AG Grid Enterprise includes built-in charting, clipboard, Excel export, column tool panels, status bars, and a full server-side row model with partial store. If you need several of these features, AG Grid covers them all in one package. No other grid matches this breadth.
+- **Enormous community and ecosystem.** With over 1M weekly npm downloads and 13k+ GitHub stars, AG Grid has the deepest community resources, Stack Overflow coverage, and third-party integrations of any data grid. Ecosystem maturity matters — and AG Grid's is unmatched.
+- **Your team already knows AG Grid.** If your developers are experienced with AG Grid's API and patterns from other projects, that familiarity has real value. Switching to a different grid has a learning cost, and AG Grid's comprehensive documentation makes it possible to find an answer for almost any scenario.
+- **You need the dedicated configuration options.** AG Grid's large API means there's often a purpose-built prop for a specific edge case. If you regularly need that level of fine-grained, per-feature configuration, the breadth of the API is a strength.
 
 ## When Infinite Table is the better fit
 
-- **You want the grid to feel like React.** Infinite Table's API is props, controlled state, and JSX — the same patterns you use in every other React component. No grid-options objects, no imperative API calls, no syncing grid state back to React. If your team thinks in React, Infinite Table fits that mental model.
-- **You want a small, composable API you can reason about.** Infinite Table ships grouping, pivoting, and aggregations with a fraction of the configuration surface. Function props instead of boolean flag forests, controlled/uncontrolled patterns instead of `suppress*` toggles, one callback where AG Grid has two with precedence rules. Fewer props, fewer interactions between props, fewer surprises.
-- **You need grouping, pivoting, and aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid gates them behind the Enterprise tier.
+- **You want the grid to feel like React.** Infinite Table's API is props, controlled state, and JSX — the same patterns you use in every other React component. If your team thinks in React, Infinite Table fits that mental model.
+- **You prefer a small, composable API.** Infinite Table ships grouping, pivoting, and aggregations with a compact configuration surface. Function props as building blocks, controlled/uncontrolled patterns for state, composable rather than exhaustive. A different bet from AG Grid's comprehensive approach — one that suits teams who want fewer props to learn and coordinate.
+- **You need grouping, pivoting, and aggregations without an enterprise license.** These are included in Infinite Table's free build. AG Grid reserves them for the Enterprise tier.
 - **Simpler licensing.** One plan, one key for the whole team, no deployment license.
 
 
@@ -138,7 +137,7 @@ AG Grid Community (MIT) does not include row grouping, pivoting, aggregations, t
 Install the package, render your first DataGrid, and learn how `<DataSource />` and `<InfiniteTable />` work together.
 </YouWillLearnCard>
 <YouWillLearnCard title="Grouping and pivoting" path="/docs/learn/grouping-and-pivoting">
-The features AG Grid Community leaves out — included here without an Enterprise license.
+Grouping, aggregations, and pivoting — included without an Enterprise license.
 </YouWillLearnCard>
 </HeroCards>
 

--- a/www/content/docs/learn/compare/ag-grid.page.md
+++ b/www/content/docs/learn/compare/ag-grid.page.md
@@ -5,13 +5,13 @@ description: A detailed comparison of Infinite Table and AG Grid for React. Two 
 
 [AG Grid](https://www.ag-grid.com/) is the most established commercial data grid on the market, used across React, Angular, Vue, and plain JavaScript. It has a massive feature surface and a large community. The AG Grid team has been shipping for over a decade and the result is an impressively comprehensive product.
 
-Infinite Table and AG Grid make different bets. This page walks through those differences honestly, including where AG Grid is the stronger choice.
+The core difference is not price. It's how each grid relates to React.
 
 ## Two different approaches to React
 
 AG Grid supports four frameworks from a single codebase. That multi-framework architecture is a genuine strength — it means your organisation can standardise on one grid across Angular, Vue, and React projects. The trade-off is that AG Grid's core is framework-agnostic: state and rendering live inside the grid engine, with a React adapter layer on top. Configuration goes through a `gridOptions` object, and many operations use imperative API calls like `api.setColumnDefs()` or `api.refreshCells()`.
 
-Infinite Table is React-only, and that choice shapes the API. Columns, sorting, grouping, and filtering are React props — controlled or uncontrolled, like any React form component. Cell renderers are plain JSX. The grid participates in React's component tree, re-rendering when props change.
+Infinite Table is built for React, and that choice shapes the API. Columns, sorting, grouping, and filtering are React props — controlled or uncontrolled, like any React form component. Cell renderers are plain JSX. The grid participates in React's component tree, re-rendering when props change.
 
 Neither approach is wrong. They reflect different design priorities: AG Grid optimises for framework reach and breadth; Infinite Table optimises for feeling native to React.
 

--- a/www/content/docs/learn/compare/index.page.md
+++ b/www/content/docs/learn/compare/index.page.md
@@ -11,7 +11,7 @@ This section compares Infinite Table with three popular alternatives. We cover h
 
 ## Comparisons
 
-- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set — but its API was designed for vanilla JS and Angular first, then wrapped for React.
+- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set — but its API was designed for vanilla JS and Angular first, then wrapped for React. Hundreds of grid-level props vs Infinite Table's small, composable surface.
 - [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed logic library. Total rendering control — but you build the UI, the virtualization, and the keyboard navigation yourself.
 - [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem. Excellent MUI integration — but grouping and pivoting require the Premium tier.
 
@@ -20,7 +20,7 @@ This section compares Infinite Table with three popular alternatives. We cover h
 | | Infinite Table | AG Grid | TanStack Table | MUI X Data Grid |
 |---|---|---|---|---|
 | **Built for React** | Yes — from the ground up | No — framework-agnostic core with React wrapper | Headless — framework-agnostic hooks | Yes — React only |
-| **API style** | Declarative props, controlled + uncontrolled | Grid-options object, imperative API | Headless hooks, you provide all JSX | Declarative props, controlled + uncontrolled |
+| **API style** | Small, composable props (controlled + uncontrolled) | Hundreds of grid options, imperative API | Headless hooks, you provide all JSX | Declarative props, controlled + uncontrolled |
 | **Cell renderers** | JSX components | AG Grid component interface (React supported) | You build all rendering | JSX components |
 | **Frameworks** | React | React, Angular, Vue, JS | React, Vue, Solid, Svelte | React |
 | **Virtualization** | Row + column | Row + column | BYO (separate package) | Row (column in Pro+) |
@@ -38,9 +38,9 @@ Feature availability is based on each product's official documentation as of mid
 
 ## How to decide
 
-**Pick Infinite Table** if you want a data grid that feels like a native React component — declarative props, controlled state, JSX renderers — with grouping, pivoting, and aggregations included out of the box, no enterprise license required.
+**Pick Infinite Table** if you want a data grid that feels like a native React component — a small, composable API of declarative props, controlled state, and JSX renderers — with grouping, pivoting, and aggregations included out of the box, no enterprise license required.
 
-**Pick AG Grid** if you need multi-framework support (Angular, Vue, and React under one grid), the widest possible feature surface (charting, clipboard, server-side row model), or you prefer an imperative API you already know from other AG Grid projects.
+**Pick AG Grid** if you need multi-framework support (Angular, Vue, and React under one grid), the widest possible feature surface (charting, clipboard, server-side row model), or your team already knows AG Grid's large API from other projects and values the coverage it provides.
 
 **Pick TanStack Table** if you want total control over rendering and are prepared to build your own UI layer, virtualization, keyboard navigation, and accessibility from scratch. Best for design-system component libraries or lightweight tables that don't need complex features.
 

--- a/www/content/docs/learn/compare/index.page.md
+++ b/www/content/docs/learn/compare/index.page.md
@@ -3,24 +3,22 @@ title: Compare React DataGrids
 description: Honest comparison of Infinite Table against AG Grid, TanStack Table, and MUI X Data Grid. Find the right React data grid for your project.
 ---
 
-Most data grids were not built for React. They were built for the browser — or for multiple frameworks at once — and later wrapped with a React adapter. The result is an API that feels foreign: grid-options objects, imperative method calls, callback registrations instead of props.
+Infinite Table was built for React from the ground up. Columns are props. Sorting, grouping, and filtering are controlled or uncontrolled values — the same pattern you use for an `<input>`. Cell renderers are plain JSX. State lives in React. When you change a prop, the grid re-renders.
 
-Infinite Table was built for React from the ground up. Columns are props. Sorting, grouping, and filtering are controlled or uncontrolled values — the same pattern you use for an `<input>`. Cell renderers are plain JSX. State lives in React, not inside the grid. When you change a prop, the grid re-renders. You're not forced to use APIs unless you want to — just React.
-
-This section compares Infinite Table with three popular alternatives. We cover how each one integrates with React, what features ship built-in, and — just as importantly — when the other tool is the better fit.
+Other excellent data grids take different approaches — multi-framework support, headless logic libraries, deep Material UI integration — and those approaches are the right choice for many teams. This section compares Infinite Table with three popular alternatives so you can decide which fits your project.
 
 ## Comparisons
 
-- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set — but its API was designed for vanilla JS and Angular first, then wrapped for React. Hundreds of grid-level props vs Infinite Table's small, composable surface.
-- [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed logic library. Total rendering control — but you build the UI, the virtualization, and the keyboard navigation yourself.
-- [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem. Excellent MUI integration — but grouping and pivoting require the Premium tier.
+- [Infinite Table vs AG Grid](/docs/learn/compare/ag-grid) — The most established enterprise data grid. Multi-framework, huge feature set. AG Grid's breadth is unmatched; Infinite Table focuses on a small, composable, React-declarative API surface.
+- [Infinite Table vs TanStack Table](/docs/learn/compare/tanstack-table) — A headless, MIT-licensed logic library. Total rendering control — you build the UI, the virtualization, and the keyboard navigation. Infinite Table ships those built-in.
+- [Infinite Table vs MUI X Data Grid](/docs/learn/compare/mui-x-data-grid) — A rendered data grid from the Material UI ecosystem. Excellent MUI integration. Infinite Table is design-system agnostic and includes grouping and pivoting without a Premium tier.
 
 ## Quick Comparison
 
 | | Infinite Table | AG Grid | TanStack Table | MUI X Data Grid |
 |---|---|---|---|---|
-| **Built for React** | Yes — from the ground up | No — framework-agnostic core with React wrapper | Headless — framework-agnostic hooks | Yes — React only |
-| **API style** | Small, composable props (controlled + uncontrolled) | Hundreds of grid options, imperative API | Headless hooks, you provide all JSX | Declarative props, controlled + uncontrolled |
+| **Built for React** | Yes — from the ground up | Multi-framework (JS, Angular, Vue, React) | Headless — multi-framework hooks | Yes — React only |
+| **API style** | Small, composable props (controlled + uncontrolled) | Large, comprehensive configuration surface | Headless hooks, you provide all JSX | Declarative props, controlled + uncontrolled |
 | **Cell renderers** | JSX components | AG Grid component interface (React supported) | You build all rendering | JSX components |
 | **Frameworks** | React | React, Angular, Vue, JS | React, Vue, Solid, Svelte | React |
 | **Virtualization** | Row + column | Row + column | BYO (separate package) | Row (column in Pro+) |
@@ -40,9 +38,9 @@ Feature availability is based on each product's official documentation as of mid
 
 **Pick Infinite Table** if you want a data grid that feels like a native React component — a small, composable API of declarative props, controlled state, and JSX renderers — with grouping, pivoting, and aggregations included out of the box, no enterprise license required.
 
-**Pick AG Grid** if you need multi-framework support (Angular, Vue, and React under one grid), the widest possible feature surface (charting, clipboard, server-side row model), or your team already knows AG Grid's large API from other projects and values the coverage it provides.
+**Pick AG Grid** if you need multi-framework support (Angular, Vue, and React under one grid), the widest possible feature surface (charting, clipboard, server-side row model), or your team already knows AG Grid from other projects and values the breadth it provides.
 
-**Pick TanStack Table** if you want total control over rendering and are prepared to build your own UI layer, virtualization, keyboard navigation, and accessibility from scratch. Best for design-system component libraries or lightweight tables that don't need complex features.
+**Pick TanStack Table** if you want total control over rendering and are prepared to build your own UI layer, virtualization, keyboard navigation, and accessibility. Best for design-system component libraries or lightweight tables that don't need complex built-in features.
 
 **Pick MUI X Data Grid** if your application is already built on Material UI and you value automatic theme integration with MUI's design system, or you need the broader MUI X component suite (date pickers, charts, tree view) under a single license.
 
@@ -67,7 +65,7 @@ Use Infinite Table free with a footer, or buy a license to remove it and get ema
 
 <HeroCards>
 <YouWillLearnCard title="vs AG Grid" path="/docs/learn/compare/ag-grid">
-React-native props versus a framework-agnostic wrapper, plus which features sit behind AG Grid Enterprise.
+How Infinite Table's React-declarative surface compares with AG Grid's multi-framework approach.
 </YouWillLearnCard>
 <YouWillLearnCard title="vs TanStack Table" path="/docs/learn/compare/tanstack-table">
 A rendered, virtualized DataGrid versus a headless table library you assemble yourself.
@@ -79,7 +77,7 @@ A rendered, virtualized DataGrid versus a headless table library you assemble yo
 What ships in Infinite Table's free build versus MUI X Community, Pro, and Premium.
 </YouWillLearnCard>
 <YouWillLearnCard title="Grouping and pivoting" path="/docs/learn/grouping-and-pivoting">
-The features most often gated on other grids — included here without an enterprise tier.
+Grouping, aggregations, and pivoting — included in every Infinite Table build.
 </YouWillLearnCard>
 </HeroCards>
 

--- a/www/content/docs/learn/compare/mui-x-data-grid.page.md
+++ b/www/content/docs/learn/compare/mui-x-data-grid.page.md
@@ -9,7 +9,7 @@ These two grids have more in common architecturally than either has with AG Grid
 
 ## Where they diverge
 
-**Design-system coupling.** MUI X Data Grid is built on Material UI. It inherits your MUI theme tokens — palette, spacing, typography — automatically. This is a major advantage if your app already uses MUI, and a friction point if it doesn't, because MUI's styling system (`@emotion`, theme provider, `sx` prop) comes along as dependencies.
+**Design-system coupling.** MUI X Data Grid is built on Material UI. It inherits your MUI theme tokens — palette, spacing, typography — automatically. This is a major advantage if your app already uses MUI. If your app uses a different design system, you'll be adding MUI's styling infrastructure (`@emotion`, theme provider, `sx` prop) as dependencies alongside your existing stack.
 
 Infinite Table is design-system agnostic. Theming is done through CSS variables — you can integrate with Tailwind, vanilla CSS, or any design system without extra dependencies. There's no coupling to a specific component library.
 
@@ -89,11 +89,11 @@ Infinite Table includes all of these features in the free Community build.
 ## When Infinite Table is the better fit
 
 - **You need grouping, pivoting, and aggregations without the Premium tier.** These are free in Infinite Table's Community build. MUI X requires Premium ($599/dev/year) for the same features.
-- **You're not using Material UI.** If your app uses Tailwind, vanilla CSS, or another design system, MUI X Data Grid brings along the MUI styling system as a dependency. Infinite Table uses plain CSS variables and works with any styling approach — no extra dependencies, no theme provider wrappers.
+- **You're not using Material UI.** If your app uses Tailwind, vanilla CSS, or another design system, Infinite Table may be a simpler fit — it uses plain CSS variables and works with any styling approach without adding a design-system dependency.
 - **Data layer separation.** Infinite Table's `<DataSource>` / `<InfiniteTable>` split gives you a clean separation between data management (fetching, sorting, grouping, pivoting, filtering) and rendering. You can even replace `<InfiniteTable>` with your own component and keep the data layer.
 - **Column virtualization on the free tier.** Infinite Table virtualizes both rows and columns by default. MUI X Community only virtualizes rows up to 100 rows; column virtualization and unlimited row virtualization require Pro.
 - **Live pagination and context menus.** Infinite Table includes built-in live pagination and context menus. MUI X does not offer equivalents at any tier.
-- **Simpler licensing model.** Infinite Table has one plan with all features. MUI X has four tiers — you need to cross-reference the pricing page to see which tier covers each feature you need.
+- **Single-tier licensing.** Infinite Table has one plan with all features included. MUI X offers four tiers, which gives you flexibility to pay only for what you need — but also means checking which tier covers each feature.
 
 
 <HeroCards>

--- a/www/content/docs/learn/compare/tanstack-table.page.md
+++ b/www/content/docs/learn/compare/tanstack-table.page.md
@@ -9,9 +9,9 @@ Infinite Table is a fully rendered React data grid. You pass props — columns, 
 
 ## Two ends of a spectrum
 
-The "Why Another DataGrid?" question comes down to a positioning choice. At one end of the spectrum is AG Grid — a full-featured grid engine that wraps itself for React. At the other end is TanStack Table — headless hooks that give you total rendering control but require you to build everything visible.
+Data grids range from fully rendered components to headless logic libraries. At one end is AG Grid — a comprehensive, multi-framework grid that handles everything. At the other end is TanStack Table — headless hooks that give you total rendering control and require you to build everything visible.
 
-Infinite Table sits in the middle: **a declarative React component that ships the grid**. You get the React-native API feel (props, controlled state, JSX cell renderers) without having to construct the table markup, virtualization, focus management, and accessibility yourself.
+Infinite Table sits in the middle: **a declarative React component that ships the grid**. You get a React-native API (props, controlled state, JSX cell renderers) without having to construct the table markup, virtualization, focus management, and accessibility yourself.
 
 ```tsx
 // TanStack Table: you provide all the JSX


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After PR #300 was merged, two additional commits landed on the stale branch `cursor/add-comparison-pages-ce71` but were never brought to master. This PR cherry-picks those two commits to bring the improved copy onto master.

### Cherry-picked commits

1. **59232849** — Add API surface / composable props section to the AG Grid comparison page (verified `GridOptions` examples, breadth-vs-composability framing).
2. **123113d1** — Respectful tone rewrite across all four comparison pages: remove "feels foreign" / "not built for React" attack framing; add "Neither approach is wrong"; more generous "when AG Grid wins" section.

### Files changed

- `www/content/docs/learn/compare/index.page.md` — Softened hub intro; balanced competitor descriptions
- `www/content/docs/learn/compare/ag-grid.page.md` — New "API surface: breadth vs composability" section; respectful framing throughout; expanded "When AG Grid is the better choice"
- `www/content/docs/learn/compare/tanstack-table.page.md` — Tone adjustments
- `www/content/docs/learn/compare/mui-x-data-grid.page.md` — Tone adjustments

### What was preserved

- Competitor "Edit on GitHub / open a PR" invitations on every page
- All feature comparison tables (no claims invented)
- Pricing comparisons (price is not the headline)
- "Help us keep this comparison up-to-date" sections

### What was NOT done

- PR #300 was not reopened
- No new claims were invented
- Price is not used as the headline differentiator
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e809f8e-3fc2-4f95-b8ae-e4b72a8e44b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e809f8e-3fc2-4f95-b8ae-e4b72a8e44b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

