### PR TITLE
Add Compare section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Our approach with the `InfiniteTable` is to go documentation first. From our dev
 
 ## ⚖️ Compare
 
-Choosing a React DataGrid is a big decision. We've put together honest comparisons so you can see where Infinite Table fits — particularly if you value a component that feels native to React (hooks, controlled/uncontrolled props, no imperative API gymnastics).
+Choosing a React DataGrid is a big decision. We've put together honest comparisons so you can see where Infinite Table fits — particularly if you value a component that feels native to React (hooks, controlled/uncontrolled props).
 
 - [Overview](https://infinite-table.com/docs/learn/compare)
 - [vs AG Grid](https://infinite-table.com/docs/learn/compare/ag-grid)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [🤔 What is Infinite Table?](#-what-is-infinite-table)
 - [📦 Installation](#-installation)
 - [📄 Extensive documentation](#-extensive-documentation)
+- [⚖️ Compare](#-compare)
 - [❤️ TypeScript](#-typescript)
 - [🏢 Enterprise-ready](#-enterprise-ready)
   - [🔒 Secure by default](#-secure-by-default)
@@ -75,6 +76,15 @@ npm install @infinite-table/infinite-react --save
 Our approach with the `InfiniteTable` is to go documentation first. From our developer experience we know that most software products lack a good documentation. So we want to be different and start with the documentation first since our purpose is to have an outstanding documentation that developers can actually use.
 
 **[Visit our docs and getting-started guide](https://infinite-table.com/docs)**
+
+## ⚖️ Compare
+
+Choosing a React DataGrid is a big decision. We've put together honest comparisons so you can see where Infinite Table fits — particularly if you value a component that feels native to React (hooks, controlled/uncontrolled props, no imperative API gymnastics).
+
+- [Overview](https://infinite-table.com/docs/learn/compare)
+- [vs AG Grid](https://infinite-table.com/docs/learn/compare/ag-grid)
+- [vs TanStack Table](https://infinite-table.com/docs/learn/compare/tanstack-table)
+- [vs MUI X Data Grid](https://infinite-table.com/docs/learn/compare/mui-x-data-grid)
 
 ## ❤️ TypeScript
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a short **Compare** section to the README, placed after the "Extensive documentation" section, with links to the live comparison pages now on master:

- https://infinite-table.com/docs/learn/compare
- https://infinite-table.com/docs/learn/compare/ag-grid
- https://infinite-table.com/docs/learn/compare/tanstack-table
- https://infinite-table.com/docs/learn/compare/mui-x-data-grid

The section highlights Infinite Table's React-native design philosophy (hooks, controlled/uncontrolled props) without benchmarks, star counts, or pricing as the hook. A matching TOC entry is included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-351f4ad1-1953-4caa-9b19-abd20d817e3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-351f4ad1-1953-4caa-9b19-abd20d817e3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

